### PR TITLE
Fix example Vite config

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Add it as plugin to `vite.config.js`
 ```js
 // vite.config.ts
 import { defineConfig } from 'vite';
-import { solidPlugin } from 'vite-plugin-solid';
+import solidPlugin from 'vite-plugin-solid';
 
 export default defineConfig({
   plugins: [solidPlugin()],


### PR DESCRIPTION
This PR contains a tiny fix to the Vite config example. Currently in the example `solidPlugin` is imported from `vite-plugin-solid`, but the plugin does not have any named export (other than `Options` type).