### PR TITLE
Fix #26

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -290,7 +290,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
     },
 
     configResolved(config) {
-      needHmr = config.command === 'serve' && !config.isProduction && options.hot !== false;
+      needHmr = config.command === 'serve' && config.mode !== 'production' && options.hot !== false;
     },
 
     resolveId(id) {
@@ -336,7 +336,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
         filename: id,
         sourceFileName: id,
         presets: [[solid, { ...solidOptions, ...(options.solid || {}) }]],
-        plugins: needHmr && !isSsr && !inNodeModules ? [[solidRefresh, { bundler: 'vite' }]] : undefined,
+        plugins: needHmr && !isSsr && !inNodeModules ? [[solidRefresh, { bundler: 'vite' }]] : [],
         sourceMaps: true,
         // Vite handles sourcemap flattening
         inputSourceMap: false as any,


### PR DESCRIPTION
- Fix `needHmr` keeps on failing due to Vite's check for `config.isProduction`, refer to https://github.com/vitejs/vite/blob/b2d972e53b59329695f74e01893b21ec5c136ffd/packages/vite/src/node/config.ts#L391-L395
- Fix `undefined` for `plugins` makes the `mergeAndConcat` fail when user adds their own plugin.

Resolves #26 