### PR TITLE
add types discoverability

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   ],
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
+  "types": "dist/types/index.d.ts",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "import": "./dist/esm/index.mjs",
     "node": "./dist/cjs/index.cjs",
     "default": "./dist/cjs/index.cjs",


### PR DESCRIPTION
To discover types in a published package we need the `types` entry in the package.json as documented [here](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html)

Fixes #32