### PR TITLE
Add 'universal' to compiler output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -197,10 +197,11 @@ export interface Options {
      * Can be:
      * - "dom" is standard output
      * - "ssr" is for server side rendering of strings.
+     * - "universal" is for using custom renderers from solid-js/universal
      *
      * @default "dom"
      */
-    generate?: 'ssr' | 'dom';
+    generate?: 'ssr' | 'dom' | 'universal';
 
     /**
      * Indicate whether the output should contain hydratable markers.


### PR DESCRIPTION
This PR adds the `'universal'` option to the compiler options so people can configure the solid plugin to generate universal output for using a custom renderer.