### PR TITLE
Fix #51 by stripping query string from id

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -245,7 +245,7 @@ export interface Options {
 
 function getExtension(filename: string): string {
   const index = filename.lastIndexOf('.');
-  return index < 0 ? '' : filename.substring(index);
+  return index < 0 ? '' : filename.substring(index).replace(/\?.+$/, '');
 }
 
 export default function solidPlugin(options: Partial<Options> = {}): Plugin {


### PR DESCRIPTION
When comparing file extensions, remove the potential version string
(e.g. `path.ext?v=jdj444`) that causes a mismatch when a match is
expected (e.g. `'.tsx?v=jdj444' != '.tsx'`).

This fixes the Vite 3.1+ error ("Failed to parse source for import
analysis because the content contains invalid JS syntax.") that
is caused by vite-plugin-solid not handling 'tsx' and 'jsx' files
due to mismatched extensions.