### PR TITLE
Fixing the link for the vite documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ if (import.meta.hot) {
 
 - It appears that Webstorm generate some weird triggers when saving a file. In order to prevent that you can follow [this thread](https://intellij-support.jetbrains.com/hc/en-us/community/posts/360000154544-I-m-having-a-huge-problem-with-Webstorm-and-react-hot-loader-) and disable the **"Safe Write"** option in **"Settings | Appearance & Behavior | System Settings"**.
 
-- If one of your dependency spit out React code instead of Solid that means that they don't expose JSX properly. To get around it, you might want to manually exclude it from the [dependencies optimization](https://vitejs.dev/config/#optimizedeps-exclude)
+- If one of your dependency spit out React code instead of Solid that means that they don't expose JSX properly. To get around it, you might want to manually exclude it from the [dependencies optimization](https://vitejs.dev/config/dep-optimization-options.html#optimizedeps-exclude)
 
 - If you are trying to make [directives](https://www.solidjs.com/docs/latest/api#use%3A___) work and they somehow don't try setting the `options.typescript.onlyRemoveTypeImports` option to `true`
 


### PR DESCRIPTION
Problem
=======

* Under some circumstances invalid code is produced assuming React being present. The documentation reflects on this issue and suggests settings some vite-specific settings, referring to the documentation, but the link is no longer valid.

Solution
========

* Update the link to the proper spot in the documentation