### PR TITLE
Fix `typeof fields[key] === 'object'` null check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -253,7 +253,7 @@ function containsSolidField(fields) {
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
     if (key === 'solid') return true;
-    if (typeof fields[key] === 'object' && containsSolidField(fields[key])) return true;
+    if (typeof fields[key] === 'object' && fields[key] != null && containsSolidField(fields[key])) return true;
   }
   return false;
 }


### PR DESCRIPTION
This should be used with caution, and has already happened in [one of our repos](https://github.com/solidjs/solid/pull/1213), because `typeof null` will return `"object"`.