### PR TITLE
Improve Solid libraries config handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "@babel/preset-typescript": "^7.18.6",
     "babel-preset-solid": "^1.4.6",
     "merge-anything": "^5.0.2",
-    "solid-refresh": "^0.4.1"
+    "solid-refresh": "^0.4.1",
+    "vitefu": "^0.1.0"
   },
   "devDependencies": {
     "@babel/plugin-transform-typescript": "^7.18.8",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "babel-preset-solid": "^1.4.6",
     "merge-anything": "^5.0.2",
     "solid-refresh": "^0.4.1",
-    "vitefu": "^0.1.0"
+    "vitefu": "^0.1.1"
   },
   "devDependencies": {
     "@babel/plugin-transform-typescript": "^7.18.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,7 @@ specifiers:
   solid-refresh: ^0.4.1
   typescript: ^4.7.4
   vite: ^3.0.0
+  vitefu: ^0.1.0
 
 dependencies:
   '@babel/core': 7.18.6
@@ -27,6 +28,7 @@ dependencies:
   babel-preset-solid: 1.4.6_@babel+core@7.18.6
   merge-anything: 5.0.2
   solid-refresh: 0.4.1_solid-js@1.4.7
+  vitefu: 0.1.0_vite@3.0.0
 
 devDependencies:
   '@babel/plugin-transform-typescript': 7.18.8_@babel+core@7.18.6
@@ -1537,7 +1539,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-android-arm64/0.14.49:
@@ -1546,7 +1547,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-darwin-64/0.14.49:
@@ -1555,7 +1555,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-darwin-arm64/0.14.49:
@@ -1564,7 +1563,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-freebsd-64/0.14.49:
@@ -1573,7 +1571,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-freebsd-arm64/0.14.49:
@@ -1582,7 +1579,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-linux-32/0.14.49:
@@ -1591,7 +1587,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-linux-64/0.14.49:
@@ -1600,7 +1595,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-linux-arm/0.14.49:
@@ -1609,7 +1603,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-linux-arm64/0.14.49:
@@ -1618,7 +1611,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-linux-mips64le/0.14.49:
@@ -1627,7 +1619,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-linux-ppc64le/0.14.49:
@@ -1636,7 +1627,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-linux-riscv64/0.14.49:
@@ -1645,7 +1635,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-linux-s390x/0.14.49:
@@ -1654,7 +1643,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-netbsd-64/0.14.49:
@@ -1663,7 +1651,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-openbsd-64/0.14.49:
@@ -1672,7 +1659,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-sunos-64/0.14.49:
@@ -1681,7 +1667,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-windows-32/0.14.49:
@@ -1690,7 +1675,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-windows-64/0.14.49:
@@ -1699,7 +1683,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-windows-arm64/0.14.49:
@@ -1708,7 +1691,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild/0.14.49:
@@ -1737,7 +1719,6 @@ packages:
       esbuild-windows-32: 0.14.49
       esbuild-windows-64: 0.14.49
       esbuild-windows-arm64: 0.14.49
-    dev: true
 
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -1769,12 +1750,10 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /function-bind/1.1.1:
     resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
-    dev: true
 
   /gensync/1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -1823,10 +1802,13 @@ packages:
     engines: {node: '>= 0.4.0'}
     dependencies:
       function-bind: 1.1.1
-    dev: true
 
   /html-entities/2.3.2:
     resolution: {integrity: sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ==}
+    dev: false
+
+  /import-meta-resolve/2.1.0:
+    resolution: {integrity: sha512-yG9pxkWJVTy4cmRsNWE3ztFdtFuYIV8G4N+cbCkO8b+qngkLyIUhxQFuZ0qJm67+0nUOxjMPT7nfksPKza1v2g==}
     dev: false
 
   /inflight/1.0.6:
@@ -1851,7 +1833,6 @@ packages:
     resolution: {integrity: sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==}
     dependencies:
       has: 1.0.3
-    dev: true
 
   /is-module/1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
@@ -1922,7 +1903,6 @@ packages:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-    dev: true
 
   /node-releases/2.0.6:
     resolution: {integrity: sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==}
@@ -1955,7 +1935,6 @@ packages:
 
   /path-parse/1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-    dev: true
 
   /picocolors/1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
@@ -1972,7 +1951,6 @@ packages:
       nanoid: 3.3.4
       picocolors: 1.0.0
       source-map-js: 1.0.2
-    dev: true
 
   /prettier/2.7.1:
     resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
@@ -2031,7 +2009,6 @@ packages:
       is-core-module: 2.9.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-    dev: true
 
   /rimraf/2.7.1:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
@@ -2056,7 +2033,6 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
 
   /safe-buffer/5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -2087,7 +2063,6 @@ packages:
   /source-map-js/1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /sourcemap-codec/1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
@@ -2102,7 +2077,6 @@ packages:
   /supports-preserve-symlinks-flag/1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /to-fast-properties/2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
@@ -2176,7 +2150,18 @@ packages:
       rollup: 2.76.0
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
+
+  /vitefu/0.1.0_vite@3.0.0:
+    resolution: {integrity: sha512-5MQSHP9yr0HIve8q4XNb7QXfO1P4tzZDZP99qH0FM5ClcwYddeGXRDQ4TQYRUeXLjZ+vLecirHtGNpwFFUF7sw==}
+    peerDependencies:
+      vite: ^3.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+    dependencies:
+      import-meta-resolve: 2.1.0
+      vite: 3.0.0
+    dev: false
 
   /wrappy/1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ specifiers:
   solid-refresh: ^0.4.1
   typescript: ^4.7.4
   vite: ^3.0.0
-  vitefu: ^0.1.0
+  vitefu: ^0.1.1
 
 dependencies:
   '@babel/core': 7.18.6
@@ -28,7 +28,7 @@ dependencies:
   babel-preset-solid: 1.4.6_@babel+core@7.18.6
   merge-anything: 5.0.2
   solid-refresh: 0.4.1_solid-js@1.4.7
-  vitefu: 0.1.0_vite@3.0.0
+  vitefu: 0.1.1_vite@3.0.0
 
 devDependencies:
   '@babel/plugin-transform-typescript': 7.18.8_@babel+core@7.18.6
@@ -1807,10 +1807,6 @@ packages:
     resolution: {integrity: sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ==}
     dev: false
 
-  /import-meta-resolve/2.1.0:
-    resolution: {integrity: sha512-yG9pxkWJVTy4cmRsNWE3ztFdtFuYIV8G4N+cbCkO8b+qngkLyIUhxQFuZ0qJm67+0nUOxjMPT7nfksPKza1v2g==}
-    dev: false
-
   /inflight/1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     dependencies:
@@ -2151,15 +2147,14 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
 
-  /vitefu/0.1.0_vite@3.0.0:
-    resolution: {integrity: sha512-5MQSHP9yr0HIve8q4XNb7QXfO1P4tzZDZP99qH0FM5ClcwYddeGXRDQ4TQYRUeXLjZ+vLecirHtGNpwFFUF7sw==}
+  /vitefu/0.1.1_vite@3.0.0:
+    resolution: {integrity: sha512-HClD14fjMJ+NQgXBqT3dC3RdO/+Chayil+cCPYZKY3kT+KcJomKzrdgzfCHJkIL2L0OAY+VPvrSW615iPtc7ag==}
     peerDependencies:
       vite: ^3.0.0
     peerDependenciesMeta:
       vite:
         optional: true
     dependencies:
-      import-meta-resolve: 2.1.0
       vite: 3.0.0
     dev: false
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,8 @@ const external = [
   "babel-preset-solid",
   "solid-refresh",
   "solid-refresh/babel.js",
-  "merge-anything"
+  "merge-anything",
+  "vitefu"
 ];
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
 import { transformAsync, TransformOptions } from '@babel/core';
 import ts from '@babel/preset-typescript';
 import solid from 'babel-preset-solid';
-import { readFileSync, existsSync } from 'fs';
-import { join, dirname } from 'path';
+import { readFileSync } from 'fs';
 import { mergeAndConcat } from 'merge-anything';
 import { createRequire } from 'module';
 import solidRefresh from 'solid-refresh/babel.js';
-import type { Alias, AliasOptions, Plugin, UserConfig } from 'vite';
+import type { Alias, AliasOptions, Plugin } from 'vite';
+import { crawlFrameworkPkgs } from 'vitefu';
 
 const require = createRequire(import.meta.url);
 
@@ -253,47 +253,10 @@ function containsSolidField(fields) {
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
     if (key === 'solid') return true;
-    if (typeof fields[key] === 'object' && fields[key] != null && containsSolidField(fields[key])) return true;
+    if (typeof fields[key] === 'object' && fields[key] != null && containsSolidField(fields[key]))
+      return true;
   }
   return false;
-}
-
-function getSolidDeps(root) {
-  const pkgPath = join(root, 'package.json');
-  if (!existsSync(pkgPath)) {
-    console.log('No package.json found at project root');
-    return [];
-  }
-  const require = createRequire(pkgPath);
-  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-  const deps = [...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.devDependencies || {})];
-  const pkgs = deps.map((dep) => {
-    try {
-      return require(`${dep}/package.json`);
-    } catch (e) {
-      try {
-        let dir = dirname(require.resolve(dep));
-        while (dir) {
-          const pkgPath = join(dir, 'package.json');
-          if (existsSync(pkgPath)) {
-            const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-            if (pkg && pkg.name === dep) return pkg;
-          }
-          const parent = dirname(dir);
-          if (parent === dir) {
-            break;
-          }
-          dir = parent;
-        }
-      } catch (e) {
-        console.log("Couldn't find package.json for", dep, e);
-      }
-    }
-  });
-  return deps.reduce((acc, dep, i) => {
-    if (pkgs[i] && pkgs[i].exports && containsSolidField(pkgs[i].exports)) acc.push(dep);
-    return acc;
-  }, []);
 }
 
 export default function solidPlugin(options: Partial<Options> = {}): Plugin {
@@ -305,7 +268,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
     name: 'solid',
     enforce: 'pre',
 
-    config(userConfig, { command }): UserConfig {
+    async config(userConfig, { command }) {
       // We inject the dev mode only if the user explicitely wants it or if we are in dev (serve) mode
       replaceDev = options.dev === true || (options.dev !== false && command === 'serve');
       projectRoot = userConfig.root;
@@ -313,7 +276,14 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
       if (!userConfig.resolve) userConfig.resolve = {};
       userConfig.resolve.alias = normalizeAliases(userConfig.resolve && userConfig.resolve.alias);
 
-      const solidDeps = getSolidDeps(projectRoot || process.cwd());
+      const solidPkgsConfig = await crawlFrameworkPkgs({
+        root: projectRoot || process.cwd(),
+        isBuild: command === 'build',
+        isFrameworkPkgByJson(pkgJson) {
+          return containsSolidField(pkgJson.exports || {});
+        },
+      });
+
       // fix for bundling dev in production
       const nestedDeps = replaceDev
         ? ['solid-js', 'solid-js/web', 'solid-js/store', 'solid-js/html', 'solid-js/h']
@@ -331,17 +301,11 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
           alias: [{ find: /^solid-refresh$/, replacement: runtimePublicPath }],
         },
         optimizeDeps: {
-          include: nestedDeps,
-          exclude: [...(userConfig.optimizeDeps?.exclude || []), ...solidDeps]
+          include: [...nestedDeps, ...solidPkgsConfig.optimizeDeps.include],
+          exclude: solidPkgsConfig.optimizeDeps.exclude,
         },
-        ssr: {
-          ...userConfig.ssr,
-          noExternal: [
-            ...(((userConfig.ssr && userConfig.ssr.noExternal) || []) as string[]),
-            ...solidDeps,
-          ],
-        },
-      } as UserConfig;
+        ssr: solidPkgsConfig.ssr,
+      };
     },
 
     configResolved(config) {


### PR DESCRIPTION
- Recursively add Solid libraries to `ssr.noExternal`
- Add Solid libraries transitive deps to `ssr.external` in dev to avoid CJS SSR transformation issues
- Add Solid libraries to `optimizeDeps.exclude` so JSX are processed by `vite-plugin-solid`
- Re-include Solid libraries transitive deps to `optimizeDeps.include` to prebundle CJS deps to ESM

Uses https://github.com/svitejs/vitefu to handle the above, which is what `vite-plugin-svelte` did before but extracted out as a package to share the same heuristic.