### PR TITLE
fix: optimizeDeps.include does not respect user config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -277,6 +277,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
       userConfig.resolve.alias = normalizeAliases(userConfig.resolve && userConfig.resolve.alias);
 
       const solidPkgsConfig = await crawlFrameworkPkgs({
+        viteUserConfig: userConfig,
         root: projectRoot || process.cwd(),
         isBuild: command === 'build',
         isFrameworkPkgByJson(pkgJson) {


### PR DESCRIPTION
This PR includes a fix for not respecting user configuration of `optimizeDeps.exclude`.