### PR TITLE
Upgrade pnpm to 7.14.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,5 +68,5 @@
     "solid-js": "^1.3.17",
     "vite": "^3.0.0"
   },
-  "packageManager": "pnpm@6.24.4"
+  "packageManager": "pnpm@7.14.2"
 }


### PR DESCRIPTION
This PR upgrade the pnpm specified in package.json to 7.14.2, to fix the warning message that saying lock file is generated with a newer version of pnpm.