### PR TITLE
Upgrade vitefu to 0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "babel-preset-solid": "^1.4.6",
     "merge-anything": "^5.0.2",
     "solid-refresh": "^0.4.1",
-    "vitefu": "^0.2.1"
+    "vitefu": "^0.2.2"
   },
   "devDependencies": {
     "@babel/plugin-transform-typescript": "^7.18.8",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "babel-preset-solid": "^1.4.6",
     "merge-anything": "^5.0.2",
     "solid-refresh": "^0.4.1",
-    "vitefu": "^0.1.1"
+    "vitefu": "^0.2.1"
   },
   "devDependencies": {
     "@babel/plugin-transform-typescript": "^7.18.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ specifiers:
   solid-refresh: ^0.4.1
   typescript: ^4.7.4
   vite: ^3.0.0
-  vitefu: ^0.2.1
+  vitefu: ^0.2.2
 
 dependencies:
   '@babel/core': 7.18.6
@@ -28,7 +28,7 @@ dependencies:
   babel-preset-solid: 1.4.6_@babel+core@7.18.6
   merge-anything: 5.0.2
   solid-refresh: 0.4.1_solid-js@1.4.7
-  vitefu: 0.2.1_vite@3.0.0
+  vitefu: 0.2.2_vite@3.0.0
 
 devDependencies:
   '@babel/plugin-transform-typescript': 7.18.8_@babel+core@7.18.6
@@ -2147,8 +2147,8 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
 
-  /vitefu/0.2.1_vite@3.0.0:
-    resolution: {integrity: sha512-clkvXTAeUf+XQKm3bhWUhT4pye+3acm6YCTGaWhxxIvZZ/QjnA3JA8Zud+z/mO5y5XYvJJhevs5Sjkv/FI8nRw==}
+  /vitefu/0.2.2_vite@3.0.0:
+    resolution: {integrity: sha512-8CKEIWPm4B4DUDN+h+hVJa9pyNi7rzc5MYmbxhs1wcMakueGFNWB5/DL30USm9qU3xUPnL4/rrLEAwwFiD1tag==}
     peerDependencies:
       vite: ^3.0.0
     peerDependenciesMeta:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ specifiers:
   solid-refresh: ^0.4.1
   typescript: ^4.7.4
   vite: ^3.0.0
-  vitefu: ^0.1.1
+  vitefu: ^0.2.1
 
 dependencies:
   '@babel/core': 7.18.6
@@ -28,7 +28,7 @@ dependencies:
   babel-preset-solid: 1.4.6_@babel+core@7.18.6
   merge-anything: 5.0.2
   solid-refresh: 0.4.1_solid-js@1.4.7
-  vitefu: 0.1.1_vite@3.0.0
+  vitefu: 0.2.1_vite@3.0.0
 
 devDependencies:
   '@babel/plugin-transform-typescript': 7.18.8_@babel+core@7.18.6
@@ -2147,8 +2147,8 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
 
-  /vitefu/0.1.1_vite@3.0.0:
-    resolution: {integrity: sha512-HClD14fjMJ+NQgXBqT3dC3RdO/+Chayil+cCPYZKY3kT+KcJomKzrdgzfCHJkIL2L0OAY+VPvrSW615iPtc7ag==}
+  /vitefu/0.2.1_vite@3.0.0:
+    resolution: {integrity: sha512-clkvXTAeUf+XQKm3bhWUhT4pye+3acm6YCTGaWhxxIvZZ/QjnA3JA8Zud+z/mO5y5XYvJJhevs5Sjkv/FI8nRw==}
     peerDependencies:
       vite: ^3.0.0
     peerDependenciesMeta:


### PR DESCRIPTION
Fix #70
Fix https://github.com/bluwy/create-vite-extra/issues/12

Upgrade from 0.1.1 to 0.2.2. The breaking changes are to API name changes that aren't used in this project, so it's safe. The release fixes issues with nested type-only packages and Deno support.

This can be merged along with #71