### PR TITLE
update babel-preset-solid to 1.6.2 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-solid",
-  "version": "2.3.10",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1305,9 +1305,9 @@
       }
     },
     "babel-plugin-jsx-dom-expressions": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.35.1.tgz",
-      "integrity": "sha512-OnSFhoYE+tfuhiNCBtC4ZZvc/4kuEaJzhVnH/FfNVkCIGCPr+lG8PLeeFejkW8GSY88Ryt9T75TFABNb7y405g==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.35.4.tgz",
+      "integrity": "sha512-Ab8W+36+XcNpyb644K537MtuhZRssgE3hmZD/08a1Z99Xfnd38tR2BZaDl7yEQvvHrb46N+eje2YjIg4VGAfVQ==",
       "requires": {
         "@babel/helper-module-imports": "7.16.0",
         "@babel/plugin-syntax-jsx": "^7.16.5",
@@ -1356,11 +1356,11 @@
       }
     },
     "babel-preset-solid": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-1.6.0.tgz",
-      "integrity": "sha512-Unv2mU+H+AQ0PiGMlwywqAJqmDRZy8kfRkTDnTup3SYIp1UFkP5KcHg76O/2+wZ7mEgY071BsgeVcV1Cw96Fvg==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-1.6.2.tgz",
+      "integrity": "sha512-5sFI34g7Jtp4r04YFWkuC1o+gnekBdPXQTJb5/6lmxi5YwzazVgKAXRwEAToC3zRaPyIYJbZUVLpOi5mDzPEuw==",
       "requires": {
-        "babel-plugin-jsx-dom-expressions": "^0.35.0"
+        "babel-plugin-jsx-dom-expressions": "^0.35.4"
       }
     },
     "balanced-match": {
@@ -2133,6 +2133,11 @@
           }
         }
       }
+    },
+    "vitefu": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-0.1.1.tgz",
+      "integrity": "sha512-HClD14fjMJ+NQgXBqT3dC3RdO/+Chayil+cCPYZKY3kT+KcJomKzrdgzfCHJkIL2L0OAY+VPvrSW615iPtc7ag=="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@babel/core": "^7.18.6",
     "@babel/preset-typescript": "^7.18.6",
-    "babel-preset-solid": "^1.4.6",
+    "babel-preset-solid": "^1.6.2",
     "merge-anything": "^5.0.2",
     "solid-refresh": "^0.4.1",
     "vitefu": "^0.1.1"


### PR DESCRIPTION
babel-preset-solid contains a compiler bugfix. see https://github.com/solidjs/solid/issues/1345. 

NPM had issues resolving babel-preset-solid from vite-plugin-ssr. I don't know why. An investigation yielded that vite-plugin-ssr used an outdated version of babel-preset-solid. I thought it would be good to update the version. 