### PR TITLE
fix: install @types/babel__core as a regular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "@babel/core": "^7.20.5",
     "@babel/preset-typescript": "^7.18.6",
+    "@types/babel__core": "^7.1.20",
     "babel-preset-solid": "^1.6.3",
     "merge-anything": "^5.1.4",
     "solid-refresh": "^0.4.1",
@@ -55,7 +56,6 @@
     "@rollup/plugin-commonjs": "^23.0.4",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@skypack/package-check": "^0.2.2",
-    "@types/babel__core": "^7.1.20",
     "@types/node": "^18.11.12",
     "prettier": "^2.8.1",
     "rollup": "^3.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,7 @@ specifiers:
 dependencies:
   '@babel/core': 7.20.5
   '@babel/preset-typescript': 7.18.6_@babel+core@7.20.5
+  '@types/babel__core': 7.1.20
   babel-preset-solid: 1.6.3_@babel+core@7.20.5
   merge-anything: 5.1.4
   solid-refresh: 0.4.1_solid-js@1.6.3
@@ -37,7 +38,6 @@ devDependencies:
   '@rollup/plugin-commonjs': 23.0.4_rollup@3.7.0
   '@rollup/plugin-node-resolve': 15.0.1_rollup@3.7.0
   '@skypack/package-check': 0.2.2
-  '@types/babel__core': 7.1.20
   '@types/node': 18.11.12
   prettier: 2.8.1
   rollup: 3.7.0
@@ -376,14 +376,6 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       chalk: 2.4.2
       js-tokens: 4.0.0
-
-  /@babel/parser/7.18.8:
-    resolution: {integrity: sha512-RSKRfYX20dyH+elbJK2uqAkVyucL+xXzhqlMD5/ZXx+dAAwpyB7HsvnHe/ZUGOF+xLr5Wx9/JoXVTj6BQE2/oA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-    dependencies:
-      '@babel/types': 7.20.5
-    dev: true
 
   /@babel/parser/7.20.5:
     resolution: {integrity: sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA==}
@@ -1579,31 +1571,27 @@ packages:
   /@types/babel__core/7.1.20:
     resolution: {integrity: sha512-PVb6Bg2QuscZ30FvOU7z4guG6c926D9YRvOxEaelzndpMsvP+YM74Q/dAFASpg2l6+XLalxSGxcq/lrgYWZtyQ==}
     dependencies:
-      '@babel/parser': 7.18.8
-      '@babel/types': 7.18.8
+      '@babel/parser': 7.20.5
+      '@babel/types': 7.20.5
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
-      '@types/babel__traverse': 7.17.1
-    dev: true
+      '@types/babel__traverse': 7.18.3
 
   /@types/babel__generator/7.6.4:
     resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
     dependencies:
       '@babel/types': 7.20.5
-    dev: true
 
   /@types/babel__template/7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
       '@babel/parser': 7.20.5
       '@babel/types': 7.20.5
-    dev: true
 
-  /@types/babel__traverse/7.17.1:
-    resolution: {integrity: sha512-kVzjari1s2YVi77D3w1yuvohV2idweYXMCDzqBiVNN63TcDWrIlTVOYpqVrvbbyOE/IyzBoTKF0fdnLPEORFxA==}
+  /@types/babel__traverse/7.18.3:
+    resolution: {integrity: sha512-1kbcJ40lLB7MHsj39U4Sh1uTd2E7rLEa79kmDpI6cy+XiXsteB3POdQomoq4FxszMrO3ZYchkhYJw7A2862b3w==}
     dependencies:
       '@babel/types': 7.20.5
-    dev: true
 
   /@types/estree/1.0.0:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}


### PR DESCRIPTION
closes https://github.com/solidjs/vite-plugin-solid/issues/81

```bash
error TS7016: Could not find a declaration file for module '@babel/core'.
```

- install `@types/babel__core` as a regular dependency