### PR TITLE
docs: fix the section Requirements of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Join [solid discord](https://discord.com/invite/solidjs) and check the [troubles
 
 ## Requirements
 
-This module 100% esm compatible. As per [this document](https://nodejs.org/api/esm.html) it is strongly recommended to have at least the version `14.13.0` of node installed.
+This module 100% ESM compatible and requires NodeJS `14.18.0` or later.
 
-You can check your current version of node by typing `node -v` in your terminal. If your version is below that one version I'd encourage you to either do an update globally or use a node version management tool such as [volta](https://volta.sh/) or [nvm](https://github.com/nvm-sh/nvm).
+You can check your current version of NodeJS by typing `node -v` in your terminal. If your version is below that one version I'd encourage you to either do an update globally or use a NodeJS version management tool such as [Volta](https://volta.sh/) or [nvm](https://github.com/nvm-sh/nvm).
 
 ## Quickstart
 


### PR DESCRIPTION
Both Vite 3 and Vite 4 require NodeJS `14.18.0` or later. The installation gives an error when the minimum version requirement is not met.

Sources: [Vite 3 migration guide](https://v3.vitejs.dev/guide/migration.html#migration-from-v2) and [Rollup 3 release](https://github.com/rollup/rollup/releases/tag/v3.0.0) (since Vite4 uses Rollup 3).