### PR TITLE
fix: :bug: fixed missing module, solidRefresh import missing .js exte…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import solid from 'babel-preset-solid';
 import { readFileSync } from 'fs';
 import { mergeAndConcat } from 'merge-anything';
 import { createRequire } from 'module';
-import solidRefresh from 'solid-refresh/babel';
+import solidRefresh from 'solid-refresh/babel.js';
 import type { Alias, AliasOptions, Plugin, UserConfig } from 'vite';
 import { crawlFrameworkPkgs } from 'vitefu';
 


### PR DESCRIPTION
when building a new project without the .js extension build fails with the following:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/use/code/test/my-app/node_modules/solid-start/node_modules/vite-plugin-solid/node_modules/solid-refresh/babel' imported from /home/use/code/test/my-app/node_modules/solid-start/node_modules/vite-plugin-solid/dist/esm/index.mjs
Did you mean to import solid-refresh/babel.js?
    at new NodeError (node:internal/errors:387:5)
    at finalizeResolution (node:internal/modules/esm/resolve:330:11)
    at moduleResolve (node:internal/modules/esm/resolve:907:10)
    at defaultResolve (node:internal/modules/esm/resolve:1115:11)
    at nextResolve (node:internal/modules/esm/loader:163:28)
    at ESMLoader.resolve (node:internal/modules/esm/loader:841:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:76:40)
    at link (node:internal/modules/esm/module_job:75:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}

``` 
