### PR TITLE
feat: determine which modules to operate on by include or exclude opt…

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,20 @@ Just use regular `vite` or `vite build` commands
 - Type: Object
 - Default: {}
 
+#### options.include
+
+- Type: (string | RegExp)[] | string | RegExp | null
+- Default: undefined
+
+A [picomatch](https://github.com/micromatch/picomatch) pattern, or array of patterns, which specifies the files the plugin should operate on.
+
+#### options.exclude
+
+- Type: (string | RegExp)[] | string | RegExp | null
+- Default: undefined
+
+A [picomatch](https://github.com/micromatch/picomatch) pattern, or array of patterns, which specifies the files to be ignored by the plugin.
+
 #### options.dev
 
 - Type: Boolean

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,6 +13,7 @@ const external = [
   'solid-refresh/babel',
   'merge-anything',
   'vitefu',
+  'vite'
 ];
 
 /**


### PR DESCRIPTION
Use `include` or `exclude` options to determine whether or not certain modules should be operated upon.  This can make it work better with other frameworks. Plugins like `vue`, `react`, `svelte` also support this.