### PR TITLE
Fixed direct access to node_modules to get jestDom

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -322,7 +322,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
                   [options.ssr ? 'ssr' : 'web']: [/\.[jt]sx?$/],
                 },
                 ...(isJestDomInstalled()
-                  ? { setupFiles: ['node_modules/@testing-library/jest-dom/extend-expect.js'] }
+                  ? { setupFiles: [require.resolve('@testing-library/jest-dom/extend-expect.js')] }
                   : {}),
                 deps: { registerNodeLoader: true },
                 ...(userConfig as UserConfig & { test: Record<string, any> }).test,


### PR DESCRIPTION
When the node_modules folder is not in the execution location but in a folder higher up the hierarchy I had an error. The fix is to not access the node_modules folder directly but use require.resolve instead. 