### PR TITLE
fix: prevent duplicating `config.test` entries

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -325,7 +325,6 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
                   ? { setupFiles: ['node_modules/@testing-library/jest-dom/extend-expect.js'] }
                   : {}),
                 deps: { registerNodeLoader: true },
-                ...(userConfig as UserConfig & { test: Record<string, any> }).test,
               },
             }
           : {};


### PR DESCRIPTION
- Fixes https://github.com/vitest-dev/vitest/issues/3439

Do not duplicate `config.test` entries on `config` plugin hook. Vite will merge these and the user provided configurations are duplicated.

Minimal reproduction:

```js
import { defineConfig } from "vitest/config";
import solidPlugin from "vite-plugin-solid";

export default defineConfig({
  plugins: [
    solidPlugin({}),
    {
      name: "log-config",
      enforce: "post",
      config(config) {
        console.log("config.test", config.test);
        console.log("config.esbuild", config.esbuild);
      },
    },
  ],

  esbuild: {
    include: [/\.js$/], // Just to demonstrate that this is also merged automatically
  },

  test: {
    reporters: ["verbose", "hanging-process"],
    coverage: {
      reporter: ["text-summary"],
    },
  },
});
```

Without fix, see how `config.test` is duplicated. Also note how `config.esbuild` is automatically merged even when this plugin does not merge those manually:

```js
config.test {
  reporters: [ 'verbose', 'hanging-process', 'verbose', 'hanging-process' ],
  coverage: { reporter: [ 'text-summary', 'text-summary' ] },
  globals: true,
  environment: 'jsdom',
  transformMode: { web: [ /\.[jt]sx?$/ ] },
  deps: { registerNodeLoader: true }
}
config.esbuild {
  include: [ /\.js$/, /\.ts$/ ],
  sourcemap: 'external',
  legalComments: 'inline'
}
```

With fix:

```js
config.test {
  reporters: [ 'verbose', 'hanging-process' ],
  coverage: { reporter: [ 'text-summary' ] },
  globals: true,
  environment: 'jsdom',
  transformMode: { web: [ /\.[jt]sx?$/ ] },
  deps: { registerNodeLoader: true }
}
config.esbuild {
  include: [ /\.js$/, /\.ts$/ ],
  sourcemap: 'external',
  legalComments: 'inline'
}
```
