### PR TITLE
Respect vite `ssr` option in first place when transforming.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { transformAsync, TransformOptions } from '@babel/core';
 import ts from '@babel/preset-typescript';
 import solid from 'babel-preset-solid';
 import { readFileSync } from 'fs';
-import { mergeAndConcat } from 'merge-anything';
+import { mergeAndConcat, mergeAndCompare } from 'merge-anything';
 import { createRequire } from 'module';
 import solidRefresh from 'solid-refresh/babel';
 import { createFilter } from 'vite';
@@ -26,12 +26,12 @@ export interface Options {
    * A [picomatch](https://github.com/micromatch/picomatch) pattern, or array of patterns, which specifies the files
    * the plugin should operate on.
    */
-  include?: FilterPattern
+  include?: FilterPattern;
   /**
    * A [picomatch](https://github.com/micromatch/picomatch) pattern, or array of patterns, which specifies the files
    * to be ignored by the plugin.
    */
-  exclude?: FilterPattern
+  exclude?: FilterPattern;
   /**
    * This will inject solid-js/dev in place of solid-js in dev mode. Has no
    * effect in prod. If set to `false`, it won't inject it in dev. This is
@@ -280,7 +280,7 @@ function isJestDomInstalled() {
 }
 
 export default function solidPlugin(options: Partial<Options> = {}): Plugin {
-  const filter = createFilter(options.include, options.exclude)
+  const filter = createFilter(options.include, options.exclude);
 
   let needHmr = false;
   let replaceDev = false;
@@ -367,7 +367,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
     },
 
     async transform(source, id, transformOptions) {
-      const isSsr = transformOptions && transformOptions.ssr;
+      const isSsrRequest = transformOptions?.ssr;
       const currentFileExtension = getExtension(id);
 
       const extensionsToWatch = [...(options.extensions || []), '.tsx', '.jsx'];
@@ -382,17 +382,28 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
 
       const inNodeModules = /node_modules/.test(id);
 
-      let solidOptions: { generate: 'ssr' | 'dom'; hydratable: boolean };
-
-      if (options.ssr) {
-        if (isSsr) {
-          solidOptions = { generate: 'ssr', hydratable: true };
-        } else {
-          solidOptions = { generate: 'dom', hydratable: true };
-        }
-      } else {
-        solidOptions = { generate: 'dom', hydratable: false };
-      }
+      const solidOptions = mergeAndCompare(
+        (origVal, newVal) => newVal ?? origVal,
+        // Default options
+        {
+          generate: 'dom',
+          hydratable: false,
+        },
+        // `ssr` shorthand
+        {
+          generate: options.ssr ? 'ssr' : undefined,
+          hydratable: options.ssr ? true : undefined,
+        },
+        // direct solid options
+        {
+          generate: options.solid?.generate,
+          hydratable: options.solid?.hydratable,
+        },
+        // vite request
+        {
+          generate: isSsrRequest ? 'ssr' : undefined,
+        },
+      );
 
       id = id.replace(/\?.+$/, '');
 
@@ -402,8 +413,9 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
         root: projectRoot,
         filename: id,
         sourceFileName: id,
-        presets: [[solid, { ...solidOptions, ...(options.solid || {}) }]],
-        plugins: needHmr && !isSsr && !inNodeModules ? [[solidRefresh, { bundler: 'vite' }]] : [],
+        presets: [[solid, solidOptions]],
+        plugins:
+          needHmr && !isSsrRequest && !inNodeModules ? [[solidRefresh, { bundler: 'vite' }]] : [],
         sourceMaps: true,
         // Vite handles sourcemap flattening
         inputSourceMap: false as any,
@@ -430,7 +442,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
 
       if (options.babel) {
         if (typeof options.babel === 'function') {
-          const babelOptions = options.babel(source, id, isSsr);
+          const babelOptions = options.babel(source, id, isSsrRequest);
           babelUserOptions = babelOptions instanceof Promise ? await babelOptions : babelOptions;
         } else {
           babelUserOptions = options.babel;


### PR DESCRIPTION
Consider the case: some tool need to load module with Solid JSX. I hit this problem two times: in  Vite plugin for prerendering certain pages, and now with css-in-js plugin, because I need to extract css from module. 
It's impossible to `ssrLoadModule` if neither `ssr: true` nor `solid: { generate: 'ssr' }` is explicitly set. At the same time, I don't need to generate SSR bundle for whole app, otherwise it will break my app.


Related #64 