### PR TITLE
Remove typescript support, by letting esbuild handle it

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,10 +41,9 @@
   },
   "homepage": "https://github.com/solidjs/vite-plugin-solid#readme",
   "dependencies": {
-    "@babel/core": "^7.20.5",
-    "@babel/preset-typescript": "^7.18.6",
+    "@babel/core": "^7.22.17",
     "@types/babel__core": "^7.1.20",
-    "babel-preset-solid": "^1.7.2",
+    "babel-preset-solid": "^1.7.7",
     "merge-anything": "^5.1.4",
     "solid-refresh": "^0.5.0",
     "vitefu": "^0.2.3"
@@ -52,6 +51,7 @@
   "devDependencies": {
     "@babel/plugin-transform-typescript": "^7.20.2",
     "@babel/preset-env": "^7.20.2",
+    "@babel/preset-typescript": "^7.18.6",
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-commonjs": "^23.0.4",
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@babel/core': ^7.20.5
+  '@babel/core': ^7.22.17
   '@babel/plugin-transform-typescript': ^7.20.2
   '@babel/preset-env': ^7.20.2
   '@babel/preset-typescript': ^7.18.6
@@ -11,30 +11,30 @@ specifiers:
   '@skypack/package-check': ^0.2.2
   '@types/babel__core': ^7.1.20
   '@types/node': ^18.11.12
-  babel-preset-solid: ^1.7.0-beta.3
+  babel-preset-solid: ^1.7.7
   merge-anything: ^5.1.4
   prettier: ^2.8.1
   rollup: ^3.7.0
   rollup-plugin-cleaner: ^1.0.0
-  solid-js: ^1.7.0-beta.3
+  solid-js: ^1.7.2
   solid-refresh: ^0.5.0
   typescript: ^4.9.4
   vite: ^4.0.0
   vitefu: ^0.2.3
 
 dependencies:
-  '@babel/core': 7.20.5
-  '@babel/preset-typescript': 7.18.6_@babel+core@7.20.5
+  '@babel/core': 7.22.17
   '@types/babel__core': 7.1.20
-  babel-preset-solid: 1.7.0-beta.3_@babel+core@7.20.5
+  babel-preset-solid: 1.7.7_@babel+core@7.22.17
   merge-anything: 5.1.4
-  solid-refresh: 0.5.0_solid-js@1.7.0-beta.3
+  solid-refresh: 0.5.0_solid-js@1.7.11
   vitefu: 0.2.3_vite@4.0.0
 
 devDependencies:
-  '@babel/plugin-transform-typescript': 7.20.2_@babel+core@7.20.5
-  '@babel/preset-env': 7.20.2_@babel+core@7.20.5
-  '@rollup/plugin-babel': 6.0.3_4j2srlqc6eykr6xzbdvv3mhtsu
+  '@babel/plugin-transform-typescript': 7.20.2_@babel+core@7.22.17
+  '@babel/preset-env': 7.20.2_@babel+core@7.22.17
+  '@babel/preset-typescript': 7.18.6_@babel+core@7.22.17
+  '@rollup/plugin-babel': 6.0.3_and2se5twrmmobjb5ricux3wau
   '@rollup/plugin-commonjs': 23.0.4_rollup@3.7.0
   '@rollup/plugin-node-resolve': 15.0.1_rollup@3.7.0
   '@skypack/package-check': 0.2.2
@@ -42,7 +42,7 @@ devDependencies:
   prettier: 2.8.1
   rollup: 3.7.0
   rollup-plugin-cleaner: 1.0.0_rollup@3.7.0
-  solid-js: 1.7.0-beta.3
+  solid-js: 1.7.11
   typescript: 4.9.4
   vite: 4.0.0_@types+node@18.11.12
 
@@ -55,35 +55,41 @@ packages:
       '@jridgewell/gen-mapping': 0.1.1
       '@jridgewell/trace-mapping': 0.3.14
 
-  /@babel/code-frame/7.18.6:
-    resolution: {integrity: sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==}
+  /@babel/code-frame/7.22.13:
+    resolution: {integrity: sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/highlight': 7.18.6
+      '@babel/highlight': 7.22.13
+      chalk: 2.4.2
 
   /@babel/compat-data/7.20.5:
     resolution: {integrity: sha512-KZXo2t10+/jxmkhNXc7pZTqRvSOIvVv/+lJwHS+B2rErwOyjuVRh60yVpb7liQ1U5t7lLJ1bz+t8tSypUZdm0g==}
     engines: {node: '>=6.9.0'}
+    dev: true
 
-  /@babel/core/7.20.5:
-    resolution: {integrity: sha512-UdOWmk4pNWTm/4DlPUl/Pt4Gz4rcEMb7CY0Y3eJl5Yz1vI8ZJGmHWaVE55LoxRjdpx0z259GE9U5STA9atUinQ==}
+  /@babel/compat-data/7.22.9:
+    resolution: {integrity: sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==}
+    engines: {node: '>=6.9.0'}
+
+  /@babel/core/7.22.17:
+    resolution: {integrity: sha512-2EENLmhpwplDux5PSsZnSbnSkB3tZ6QTksgO25xwEL7pIDcNOMhF5v/s6RzwjMZzZzw9Ofc30gHv5ChCC8pifQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@ampproject/remapping': 2.2.0
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.5
-      '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.20.5
-      '@babel/helper-module-transforms': 7.20.2
-      '@babel/helpers': 7.20.6
-      '@babel/parser': 7.20.5
-      '@babel/template': 7.18.10
-      '@babel/traverse': 7.20.5
-      '@babel/types': 7.20.5
+      '@babel/code-frame': 7.22.13
+      '@babel/generator': 7.22.15
+      '@babel/helper-compilation-targets': 7.22.15
+      '@babel/helper-module-transforms': 7.22.17_@babel+core@7.22.17
+      '@babel/helpers': 7.22.15
+      '@babel/parser': 7.22.16
+      '@babel/template': 7.22.15
+      '@babel/traverse': 7.22.17
+      '@babel/types': 7.22.17
       convert-source-map: 1.8.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
-      json5: 2.2.1
-      semver: 6.3.0
+      json5: 2.2.3
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
@@ -91,51 +97,65 @@ packages:
     resolution: {integrity: sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.22.17
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
+    dev: false
 
-  /@babel/generator/7.20.5:
-    resolution: {integrity: sha512-jl7JY2Ykn9S0yj4DQP82sYvPU+T3g0HFcWTqDLqiuA9tGRNIj9VfbtXGAYTTkyNEnQk1jkMGOdYka8aG/lulCA==}
+  /@babel/generator/7.22.15:
+    resolution: {integrity: sha512-Zu9oWARBqeVOW0dZOjXc3JObrzuqothQ3y/n1kUtrjCoCPLkXUwMvOo/F/TCfoHMbWIFlWwpZtkZVb9ga4U2pA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.22.17
       '@jridgewell/gen-mapping': 0.3.2
+      '@jridgewell/trace-mapping': 0.3.19
       jsesc: 2.5.2
 
   /@babel/helper-annotate-as-pure/7.18.6:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.22.17
+    dev: true
 
   /@babel/helper-builder-binary-assignment-operator-visitor/7.18.6:
     resolution: {integrity: sha512-KT10c1oWEpmrIRYnthbzHgoOf6B+Xd6a5yhdbNtdhtG7aO1or5HViuf1TQR36xY/QprXA5nvxO6nAjhJ4y38jw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.18.6
-      '@babel/types': 7.20.7
+      '@babel/types': 7.22.17
     dev: true
 
-  /@babel/helper-compilation-targets/7.20.0_@babel+core@7.20.5:
+  /@babel/helper-compilation-targets/7.20.0_@babel+core@7.22.17:
     resolution: {integrity: sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/compat-data': 7.20.5
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-validator-option': 7.18.6
       browserslist: 4.21.4
       semver: 6.3.0
+    dev: true
 
-  /@babel/helper-create-class-features-plugin/7.20.5_@babel+core@7.20.5:
+  /@babel/helper-compilation-targets/7.22.15:
+    resolution: {integrity: sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/compat-data': 7.22.9
+      '@babel/helper-validator-option': 7.22.15
+      browserslist: 4.21.10
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  /@babel/helper-create-class-features-plugin/7.20.5_@babel+core@7.22.17:
     resolution: {integrity: sha512-3RCdA/EmEaikrhayahwToF0fpweU/8o2p8vhc1c/1kftHOdTKuC65kik/TLc+qfbS8JKw4qqJbne4ovICDhmww==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-function-name': 7.19.0
@@ -145,41 +165,42 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
-  /@babel/helper-create-regexp-features-plugin/7.18.6_@babel+core@7.20.5:
+  /@babel/helper-create-regexp-features-plugin/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-7LcpH1wnQLGrI+4v+nPp+zUvIkF9x0ddv1Hkdue10tg3gmRnLy97DXh4STiOf1qeIInyD69Qv5kKSZzKD8B/7A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-annotate-as-pure': 7.18.6
       regexpu-core: 5.1.0
     dev: true
 
-  /@babel/helper-create-regexp-features-plugin/7.20.5_@babel+core@7.20.5:
+  /@babel/helper-create-regexp-features-plugin/7.20.5_@babel+core@7.22.17:
     resolution: {integrity: sha512-m68B1lkg3XDGX5yCvGO0kPx3v9WIYLnzjKfPcQiwntEQa5ZeRkPmo2X/ISJc8qxWGfwUr+kvZAeEzAwLec2r2w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-annotate-as-pure': 7.18.6
       regexpu-core: 5.2.2
     dev: true
 
-  /@babel/helper-define-polyfill-provider/0.3.3_@babel+core@7.20.5:
+  /@babel/helper-define-polyfill-provider/0.3.3_@babel+core@7.22.17:
     resolution: {integrity: sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==}
     peerDependencies:
       '@babel/core': ^7.4.0-0
     dependencies:
-      '@babel/core': 7.20.5
-      '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.20.5
+      '@babel/core': 7.22.17
+      '@babel/helper-compilation-targets': 7.22.15
       '@babel/helper-plugin-utils': 7.20.2
       debug: 4.3.4
       lodash.debounce: 4.0.8
       resolve: 1.22.1
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -187,32 +208,53 @@ packages:
   /@babel/helper-environment-visitor/7.18.9:
     resolution: {integrity: sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==}
     engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-environment-visitor/7.22.5:
+    resolution: {integrity: sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==}
+    engines: {node: '>=6.9.0'}
 
   /@babel/helper-explode-assignable-expression/7.18.6:
     resolution: {integrity: sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.22.17
     dev: true
 
   /@babel/helper-function-name/7.19.0:
     resolution: {integrity: sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.18.10
-      '@babel/types': 7.20.7
+      '@babel/template': 7.22.15
+      '@babel/types': 7.22.17
+    dev: true
+
+  /@babel/helper-function-name/7.22.5:
+    resolution: {integrity: sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.22.15
+      '@babel/types': 7.22.17
 
   /@babel/helper-hoist-variables/7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.22.17
+    dev: true
+
+  /@babel/helper-hoist-variables/7.22.5:
+    resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.17
 
   /@babel/helper-member-expression-to-functions/7.18.9:
     resolution: {integrity: sha512-RxifAh2ZoVU67PyKIO4AMi1wTenGfMR/O/ae0CCRqwgBAt5v7xjdtRw7UoSbsreKrQn5t7r89eruK/9JjYHuDg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.22.17
+    dev: true
 
   /@babel/helper-module-imports/7.18.6:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
@@ -220,62 +262,83 @@ packages:
     dependencies:
       '@babel/types': 7.20.7
 
+  /@babel/helper-module-imports/7.22.15:
+    resolution: {integrity: sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.17
+
   /@babel/helper-module-transforms/7.20.2:
     resolution: {integrity: sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-module-imports': 7.18.6
       '@babel/helper-simple-access': 7.20.2
-      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.19.1
-      '@babel/template': 7.18.10
-      '@babel/traverse': 7.20.5
-      '@babel/types': 7.20.7
+      '@babel/template': 7.22.15
+      '@babel/traverse': 7.22.17
+      '@babel/types': 7.22.17
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@babel/helper-module-transforms/7.22.17_@babel+core@7.22.17:
+    resolution: {integrity: sha512-XouDDhQESrLHTpnBtCKExJdyY4gJCdrvH2Pyv8r8kovX2U8G0dRUOT45T9XlbLtuu9CLXP15eusnkprhoPV5iQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.22.17
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-module-imports': 7.22.15
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-validator-identifier': 7.22.15
 
   /@babel/helper-optimise-call-expression/7.18.6:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.22.17
+    dev: true
 
   /@babel/helper-plugin-utils/7.18.6:
     resolution: {integrity: sha512-gvZnm1YAAxh13eJdkb9EWHBnF3eAub3XTLCZEehHT2kWxiKVRL64+ae5Y6Ivne0mVHmMYKT+xWgZO+gQhuLUBg==}
     engines: {node: '>=6.9.0'}
-    dev: false
+    dev: true
 
   /@babel/helper-plugin-utils/7.20.2:
     resolution: {integrity: sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/helper-remap-async-to-generator/7.18.6_@babel+core@7.20.5:
+  /@babel/helper-remap-async-to-generator/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-z5wbmV55TveUPZlCLZvxWHtrjuJd+8inFhk7DG0WW87/oJuGDcjDiu7HIvGcpf5464L6xKCg3vNkmlVVz9hwyQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-wrap-function': 7.18.6
-      '@babel/types': 7.20.7
+      '@babel/types': 7.22.17
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helper-remap-async-to-generator/7.18.9_@babel+core@7.20.5:
+  /@babel/helper-remap-async-to-generator/7.18.9_@babel+core@7.22.17:
     resolution: {integrity: sha512-dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-wrap-function': 7.20.5
-      '@babel/types': 7.20.7
+      '@babel/types': 7.22.17
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -284,53 +347,81 @@ packages:
     resolution: {integrity: sha512-T7ahH7wV0Hfs46SFh5Jz3s0B6+o8g3c+7TMxu7xKfmHikg7EAZ3I2Qk9LFhjxXq8sL7UkP5JflezNwoZa8WvWw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-member-expression-to-functions': 7.18.9
       '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/traverse': 7.20.5
-      '@babel/types': 7.20.7
+      '@babel/traverse': 7.22.17
+      '@babel/types': 7.22.17
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/helper-simple-access/7.20.2:
     resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.22.17
+    dev: true
+
+  /@babel/helper-simple-access/7.22.5:
+    resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.17
 
   /@babel/helper-skip-transparent-expression-wrappers/7.20.0:
     resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.22.17
     dev: true
 
   /@babel/helper-split-export-declaration/7.18.6:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.22.17
+    dev: true
+
+  /@babel/helper-split-export-declaration/7.22.6:
+    resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.17
 
   /@babel/helper-string-parser/7.19.4:
     resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
+    engines: {node: '>=6.9.0'}
+
+  /@babel/helper-string-parser/7.22.5:
+    resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
     engines: {node: '>=6.9.0'}
 
   /@babel/helper-validator-identifier/7.19.1:
     resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
     engines: {node: '>=6.9.0'}
 
+  /@babel/helper-validator-identifier/7.22.15:
+    resolution: {integrity: sha512-4E/F9IIEi8WR94324mbDUMo074YTheJmd7eZF5vITTeYchqAi6sYXRLHUVsmkdmY4QjfKTcB2jB7dVP3NaBElQ==}
+    engines: {node: '>=6.9.0'}
+
   /@babel/helper-validator-option/7.18.6:
     resolution: {integrity: sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-validator-option/7.22.15:
+    resolution: {integrity: sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==}
     engines: {node: '>=6.9.0'}
 
   /@babel/helper-wrap-function/7.18.6:
     resolution: {integrity: sha512-I5/LZfozwMNbwr/b1vhhuYD+J/mU+gfGAj5td7l5Rv9WYmH6i3Om69WGKNmlIpsVW/mF6O5bvTKbvDQZVgjqOw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-function-name': 7.19.0
-      '@babel/template': 7.18.10
-      '@babel/traverse': 7.20.5
-      '@babel/types': 7.20.7
+      '@babel/helper-function-name': 7.22.5
+      '@babel/template': 7.22.15
+      '@babel/traverse': 7.22.17
+      '@babel/types': 7.22.17
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -339,29 +430,29 @@ packages:
     resolution: {integrity: sha512-bYMxIWK5mh+TgXGVqAtnu5Yn1un+v8DDZtqyzKRLUzrh70Eal2O3aZ7aPYiMADO4uKlkzOiRiZ6GX5q3qxvW9Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-function-name': 7.19.0
-      '@babel/template': 7.18.10
-      '@babel/traverse': 7.20.5
-      '@babel/types': 7.20.7
+      '@babel/helper-function-name': 7.22.5
+      '@babel/template': 7.22.15
+      '@babel/traverse': 7.22.17
+      '@babel/types': 7.22.17
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helpers/7.20.6:
-    resolution: {integrity: sha512-Pf/OjgfgFRW5bApskEz5pvidpim7tEDPlFtKcNRXWmfHGn9IEI2W2flqRQXTFb7gIPTyK++N6rVHuwKut4XK6w==}
+  /@babel/helpers/7.22.15:
+    resolution: {integrity: sha512-7pAjK0aSdxOwR+CcYAqgWOGy5dcfvzsTIfFTb2odQqW47MDfv14UaJDY6eng8ylM2EaeKXdxaSWESbkmaQHTmw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.18.10
-      '@babel/traverse': 7.20.5
-      '@babel/types': 7.20.7
+      '@babel/template': 7.22.15
+      '@babel/traverse': 7.22.17
+      '@babel/types': 7.22.17
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/highlight/7.18.6:
-    resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
+  /@babel/highlight/7.22.13:
+    resolution: {integrity: sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/helper-validator-identifier': 7.22.15
       chalk: 2.4.2
       js-tokens: 4.0.0
 
@@ -370,425 +461,433 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.22.17
 
-  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.18.6_@babel+core@7.20.5:
+  /@babel/parser/7.22.16:
+    resolution: {integrity: sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.22.17
+
+  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.18.9_@babel+core@7.20.5:
+  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.18.9_@babel+core@7.22.17:
     resolution: {integrity: sha512-AHrP9jadvH7qlOj6PINbgSuphjQUAK7AOT7DPjBo9EHoLhQTnnK5u45e1Hd4DbSQEO9nqPWtQ89r+XEOWFScKg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.13.0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/plugin-proposal-optional-chaining': 7.18.9_@babel+core@7.20.5
+      '@babel/plugin-proposal-optional-chaining': 7.18.9_@babel+core@7.22.17
     dev: true
 
-  /@babel/plugin-proposal-async-generator-functions/7.20.1_@babel+core@7.20.5:
+  /@babel/plugin-proposal-async-generator-functions/7.20.1_@babel+core@7.22.17:
     resolution: {integrity: sha512-Gh5rchzSwE4kC+o/6T8waD0WHEQIsDmjltY8WnWRXHUdH8axZhuH86Ov9M72YhJfDrZseQwuuWaaIT/TmePp3g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-remap-async-to-generator': 7.18.9_@babel+core@7.20.5
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.20.5
+      '@babel/helper-remap-async-to-generator': 7.18.9_@babel+core@7.22.17
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.22.17
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-class-properties/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-proposal-class-properties/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
-      '@babel/helper-create-class-features-plugin': 7.20.5_@babel+core@7.20.5
+      '@babel/core': 7.22.17
+      '@babel/helper-create-class-features-plugin': 7.20.5_@babel+core@7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-class-static-block/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-proposal-class-static-block/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-+I3oIiNxrCpup3Gi8n5IGMwj0gOCAjcJUSQEcotNnCCPMEnixawOQ+KeJPlgfjzx+FKQ1QSyZOWe7wmoJp7vhw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
-      '@babel/core': 7.20.5
-      '@babel/helper-create-class-features-plugin': 7.20.5_@babel+core@7.20.5
+      '@babel/core': 7.22.17
+      '@babel/helper-create-class-features-plugin': 7.20.5_@babel+core@7.22.17
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.20.5
+      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.22.17
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-dynamic-import/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-proposal-dynamic-import/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-1auuwmK+Rz13SJj36R+jqFPMJWyKEDd7lLSdOj4oJK0UTgGueSAtkrCvz9ewmgyU/P941Rv2fQwZJN8s6QruXw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.20.5
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.22.17
     dev: true
 
-  /@babel/plugin-proposal-export-namespace-from/7.18.9_@babel+core@7.20.5:
+  /@babel/plugin-proposal-export-namespace-from/7.18.9_@babel+core@7.22.17:
     resolution: {integrity: sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.20.5
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.22.17
     dev: true
 
-  /@babel/plugin-proposal-json-strings/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-proposal-json-strings/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-lr1peyn9kOdbYc0xr0OdHTZ5FMqS6Di+H0Fz2I/JwMzGmzJETNeOFq2pBySw6X/KFL5EWDjlJuMsUGRFb8fQgQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.20.5
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.22.17
     dev: true
 
-  /@babel/plugin-proposal-logical-assignment-operators/7.18.9_@babel+core@7.20.5:
+  /@babel/plugin-proposal-logical-assignment-operators/7.18.9_@babel+core@7.22.17:
     resolution: {integrity: sha512-128YbMpjCrP35IOExw2Fq+x55LMP42DzhOhX2aNNIdI9avSWl2PI0yuBWarr3RYpZBSPtabfadkH2yeRiMD61Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.20.5
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.22.17
     dev: true
 
-  /@babel/plugin-proposal-nullish-coalescing-operator/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-proposal-nullish-coalescing-operator/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.20.5
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.22.17
     dev: true
 
-  /@babel/plugin-proposal-numeric-separator/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-proposal-numeric-separator/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.20.5
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.22.17
     dev: true
 
-  /@babel/plugin-proposal-object-rest-spread/7.20.2_@babel+core@7.20.5:
+  /@babel/plugin-proposal-object-rest-spread/7.20.2_@babel+core@7.22.17:
     resolution: {integrity: sha512-Ks6uej9WFK+fvIMesSqbAto5dD8Dz4VuuFvGJFKgIGSkJuRGcrwGECPA1fDgQK3/DbExBJpEkTeYeB8geIFCSQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.20.5
-      '@babel/core': 7.20.5
-      '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.20.5
+      '@babel/core': 7.22.17
+      '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.22.17
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.20.5
-      '@babel/plugin-transform-parameters': 7.20.5_@babel+core@7.20.5
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.22.17
+      '@babel/plugin-transform-parameters': 7.20.5_@babel+core@7.22.17
     dev: true
 
-  /@babel/plugin-proposal-optional-catch-binding/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-proposal-optional-catch-binding/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.20.5
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.22.17
     dev: true
 
-  /@babel/plugin-proposal-optional-chaining/7.18.9_@babel+core@7.20.5:
+  /@babel/plugin-proposal-optional-chaining/7.18.9_@babel+core@7.22.17:
     resolution: {integrity: sha512-v5nwt4IqBXihxGsW2QmCWMDS3B3bzGIk/EQVZz2ei7f3NJl8NzAJVvUmpDW5q1CRNY+Beb/k58UAH1Km1N411w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.20.5
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.22.17
     dev: true
 
-  /@babel/plugin-proposal-private-methods/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-proposal-private-methods/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
-      '@babel/helper-create-class-features-plugin': 7.20.5_@babel+core@7.20.5
+      '@babel/core': 7.22.17
+      '@babel/helper-create-class-features-plugin': 7.20.5_@babel+core@7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-private-property-in-object/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-proposal-private-property-in-object/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-9Rysx7FOctvT5ouj5JODjAFAkgGoudQuLPamZb0v1TGLpapdNaftzifU8NTWQm0IRjqoYypdrSmyWgkocDQ8Dw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-create-class-features-plugin': 7.20.5_@babel+core@7.20.5
+      '@babel/helper-create-class-features-plugin': 7.20.5_@babel+core@7.22.17
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.20.5
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.22.17
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-unicode-property-regex/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-proposal-unicode-property-regex/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==}
     engines: {node: '>=4'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
-      '@babel/helper-create-regexp-features-plugin': 7.18.6_@babel+core@7.20.5
+      '@babel/core': 7.22.17
+      '@babel/helper-create-regexp-features-plugin': 7.18.6_@babel+core@7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.20.5:
+  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.22.17:
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.20.5:
+  /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.22.17:
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-class-static-block/7.14.5_@babel+core@7.20.5:
+  /@babel/plugin-syntax-class-static-block/7.14.5_@babel+core@7.22.17:
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.20.5:
+  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.22.17:
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.20.5:
+  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.22.17:
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-import-assertions/7.20.0_@babel+core@7.20.5:
+  /@babel/plugin-syntax-import-assertions/7.20.0_@babel+core@7.22.17:
     resolution: {integrity: sha512-IUh1vakzNoWalR8ch/areW7qFopR2AEw03JlG7BbrDqmQ4X3q9uuipQwSGrUn7oGiemKjtSLDhNtQHzMHr1JdQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.20.5:
+  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.22.17:
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-jsx/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-syntax-jsx/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.20.5:
+  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.22.17:
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.20.5:
+  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.22.17:
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.20.5:
+  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.22.17:
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.20.5:
+  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.22.17:
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.20.5:
+  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.22.17:
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.20.5:
+  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.22.17:
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-private-property-in-object/7.14.5_@babel+core@7.20.5:
+  /@babel/plugin-syntax-private-property-in-object/7.14.5_@babel+core@7.22.17:
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.20.5:
+  /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.22.17:
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-typescript/7.20.0_@babel+core@7.20.5:
+  /@babel/plugin-syntax-typescript/7.20.0_@babel+core@7.22.17:
     resolution: {integrity: sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
-  /@babel/plugin-transform-arrow-functions/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-transform-arrow-functions/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-9S9X9RUefzrsHZmKMbDXxweEH+YlE8JJEuat9FdvW9Qh1cw7W64jELCtWNkPBPX5En45uy28KGvA/AySqUh8CQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-async-to-generator/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-transform-async-to-generator/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-ARE5wZLKnTgPW7/1ftQmSi1CmkqqHo2DNmtztFhvgtOWSDfq0Cq9/9L+KnZNYSNrydBekhW3rwShduf59RoXag==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-module-imports': 7.18.6
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-remap-async-to-generator': 7.18.6_@babel+core@7.20.5
+      '@babel/helper-remap-async-to-generator': 7.18.6_@babel+core@7.22.17
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-block-scoped-functions/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-transform-block-scoped-functions/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-block-scoping/7.20.5_@babel+core@7.20.5:
+  /@babel/plugin-transform-block-scoping/7.20.5_@babel+core@7.22.17:
     resolution: {integrity: sha512-WvpEIW9Cbj9ApF3yJCjIEEf1EiNJLtXagOrL5LNWEZOo3jv8pmPoYTSNJQvqej8OavVlgOoOPw6/htGZro6IkA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-classes/7.20.2_@babel+core@7.20.5:
+  /@babel/plugin-transform-classes/7.20.2_@babel+core@7.22.17:
     resolution: {integrity: sha512-9rbPp0lCVVoagvtEyQKSo5L8oo0nQS/iif+lwlAz29MccX2642vWDlSZK+2T2buxbopotId2ld7zZAzRfz9j1g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.20.5
+      '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.22.17
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-function-name': 7.19.0
       '@babel/helper-optimise-call-expression': 7.18.6
@@ -800,120 +899,120 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-computed-properties/7.18.9_@babel+core@7.20.5:
+  /@babel/plugin-transform-computed-properties/7.18.9_@babel+core@7.22.17:
     resolution: {integrity: sha512-+i0ZU1bCDymKakLxn5srGHrsAPRELC2WIbzwjLhHW9SIE1cPYkLCL0NlnXMZaM1vhfgA2+M7hySk42VBvrkBRw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-destructuring/7.20.2_@babel+core@7.20.5:
+  /@babel/plugin-transform-destructuring/7.20.2_@babel+core@7.22.17:
     resolution: {integrity: sha512-mENM+ZHrvEgxLTBXUiQ621rRXZes3KWUv6NdQlrnr1TkWVw+hUjQBZuP2X32qKlrlG2BzgR95gkuCRSkJl8vIw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-dotall-regex/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-transform-dotall-regex/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-6S3jpun1eEbAxq7TdjLotAsl4WpQI9DxfkycRcKrjhQYzU87qpXdknpBg/e+TdcMehqGnLFi7tnFUBR02Vq6wg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
-      '@babel/helper-create-regexp-features-plugin': 7.18.6_@babel+core@7.20.5
+      '@babel/core': 7.22.17
+      '@babel/helper-create-regexp-features-plugin': 7.18.6_@babel+core@7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-duplicate-keys/7.18.9_@babel+core@7.20.5:
+  /@babel/plugin-transform-duplicate-keys/7.18.9_@babel+core@7.22.17:
     resolution: {integrity: sha512-d2bmXCtZXYc59/0SanQKbiWINadaJXqtvIQIzd4+hNwkWBgyCd5F/2t1kXoUdvPMrxzPvhK6EMQRROxsue+mfw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-exponentiation-operator/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-transform-exponentiation-operator/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-wzEtc0+2c88FVR34aQmiz56dxEkxr2g8DQb/KfaFa1JYXOFVsbhvAonFN6PwVWj++fKmku8NP80plJ5Et4wqHw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.6
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-for-of/7.18.8_@babel+core@7.20.5:
+  /@babel/plugin-transform-for-of/7.18.8_@babel+core@7.22.17:
     resolution: {integrity: sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-function-name/7.18.9_@babel+core@7.20.5:
+  /@babel/plugin-transform-function-name/7.18.9_@babel+core@7.22.17:
     resolution: {integrity: sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
-      '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.20.5
+      '@babel/core': 7.22.17
+      '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.22.17
       '@babel/helper-function-name': 7.19.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-literals/7.18.9_@babel+core@7.20.5:
+  /@babel/plugin-transform-literals/7.18.9_@babel+core@7.22.17:
     resolution: {integrity: sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-member-expression-literals/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-transform-member-expression-literals/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-modules-amd/7.19.6_@babel+core@7.20.5:
+  /@babel/plugin-transform-modules-amd/7.19.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-uG3od2mXvAtIFQIh0xrpLH6r5fpSQN04gIVovl+ODLdUMANokxQLZnPBHcjmv3GxRjnqwLuHvppjjcelqUFZvg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-module-transforms': 7.20.2
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-modules-commonjs/7.19.6_@babel+core@7.20.5:
+  /@babel/plugin-transform-modules-commonjs/7.19.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-8PIa1ym4XRTKuSsOUXqDG0YaOlEuTVvHMe5JCfgBMOtHvJKw/4NGovEGN33viISshG/rZNVrACiBmPQLvWN8xQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-module-transforms': 7.20.2
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-simple-access': 7.20.2
@@ -921,13 +1020,13 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-modules-systemjs/7.19.6_@babel+core@7.20.5:
+  /@babel/plugin-transform-modules-systemjs/7.19.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-fqGLBepcc3kErfR9R3DnVpURmckXP7gj7bAlrTQyBxrigFqszZCkFkcoxzCp2v32XmwXLvbw+8Yq9/b+QqksjQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-module-transforms': 7.20.2
       '@babel/helper-plugin-utils': 7.20.2
@@ -936,291 +1035,292 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-modules-umd/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-transform-modules-umd/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-dcegErExVeXcRqNtkRU/z8WlBLnvD4MRnHgNs3MytRO1Mn1sHRyhbcpYbVMGclAqOjdW+9cfkdZno9dFdfKLfQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-module-transforms': 7.20.2
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-named-capturing-groups-regex/7.20.5_@babel+core@7.20.5:
+  /@babel/plugin-transform-named-capturing-groups-regex/7.20.5_@babel+core@7.22.17:
     resolution: {integrity: sha512-mOW4tTzi5iTLnw+78iEq3gr8Aoq4WNRGpmSlrogqaiCBoR1HFhpU4JkpQFOHfeYx3ReVIFWOQJS4aZBRvuZ6mA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.5
-      '@babel/helper-create-regexp-features-plugin': 7.20.5_@babel+core@7.20.5
+      '@babel/core': 7.22.17
+      '@babel/helper-create-regexp-features-plugin': 7.20.5_@babel+core@7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-new-target/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-transform-new-target/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-DjwFA/9Iu3Z+vrAn+8pBUGcjhxKguSMlsFqeCKbhb9BAV756v0krzVK04CRDi/4aqmk8BsHb4a/gFcaA5joXRw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-object-super/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-transform-object-super/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-replace-supers': 7.19.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-parameters/7.20.5_@babel+core@7.20.5:
+  /@babel/plugin-transform-parameters/7.20.5_@babel+core@7.22.17:
     resolution: {integrity: sha512-h7plkOmcndIUWXZFLgpbrh2+fXAi47zcUX7IrOQuZdLD0I0KvjJ6cvo3BEcAOsDOcZhVKGJqv07mkSqK0y2isQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-property-literals/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-transform-property-literals/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-regenerator/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-transform-regenerator/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-poqRI2+qiSdeldcz4wTSTXBRryoq3Gc70ye7m7UD5Ww0nE29IXqMl6r7Nd15WBgRd74vloEMlShtH6CKxVzfmQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
       regenerator-transform: 0.15.0
     dev: true
 
-  /@babel/plugin-transform-reserved-words/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-transform-reserved-words/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-oX/4MyMoypzHjFrT1CdivfKZ+XvIPMFXwwxHp/r0Ddy2Vuomt4HDFGmft1TAY2yiTKiNSsh3kjBAzcM8kSdsjA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-shorthand-properties/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-transform-shorthand-properties/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-spread/7.19.0_@babel+core@7.20.5:
+  /@babel/plugin-transform-spread/7.19.0_@babel+core@7.22.17:
     resolution: {integrity: sha512-RsuMk7j6n+r752EtzyScnWkQyuJdli6LdO5Klv8Yx0OfPVTcQkIUfS8clx5e9yHXzlnhOZF3CbQ8C2uP5j074w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
     dev: true
 
-  /@babel/plugin-transform-sticky-regex/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-transform-sticky-regex/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-kfiDrDQ+PBsQDO85yj1icueWMfGfJFKN1KCkndygtu/C9+XUfydLC8Iv5UYJqRwy4zk8EcplRxEOeLyjq1gm6Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-template-literals/7.18.9_@babel+core@7.20.5:
+  /@babel/plugin-transform-template-literals/7.18.9_@babel+core@7.22.17:
     resolution: {integrity: sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-typeof-symbol/7.18.9_@babel+core@7.20.5:
+  /@babel/plugin-transform-typeof-symbol/7.18.9_@babel+core@7.22.17:
     resolution: {integrity: sha512-SRfwTtF11G2aemAZWivL7PD+C9z52v9EvMqH9BuYbabyPuKUvSWks3oCg6041pT925L4zVFqaVBeECwsmlguEw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-typescript/7.20.2_@babel+core@7.20.5:
+  /@babel/plugin-transform-typescript/7.20.2_@babel+core@7.22.17:
     resolution: {integrity: sha512-jvS+ngBfrnTUBfOQq8NfGnSbF9BrqlR6hjJ2yVxMkmO5nL/cdifNbI30EfjRlN4g5wYWNnMPyj5Sa6R1pbLeag==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
-      '@babel/helper-create-class-features-plugin': 7.20.5_@babel+core@7.20.5
+      '@babel/core': 7.22.17
+      '@babel/helper-create-class-features-plugin': 7.20.5_@babel+core@7.22.17
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-typescript': 7.20.0_@babel+core@7.20.5
+      '@babel/plugin-syntax-typescript': 7.20.0_@babel+core@7.22.17
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
-  /@babel/plugin-transform-unicode-escapes/7.18.10_@babel+core@7.20.5:
+  /@babel/plugin-transform-unicode-escapes/7.18.10_@babel+core@7.22.17:
     resolution: {integrity: sha512-kKAdAI+YzPgGY/ftStBFXTI1LZFju38rYThnfMykS+IXy8BVx+res7s2fxf1l8I35DV2T97ezo6+SGrXz6B3iQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-unicode-regex/7.18.6_@babel+core@7.20.5:
+  /@babel/plugin-transform-unicode-regex/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-gE7A6Lt7YLnNOL3Pb9BNeZvi+d8l7tcRrG4+pwJjK9hD2xX4mEvjlQW60G9EEmfXVYRPv9VRQcyegIVHCql/AA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
-      '@babel/helper-create-regexp-features-plugin': 7.18.6_@babel+core@7.20.5
+      '@babel/core': 7.22.17
+      '@babel/helper-create-regexp-features-plugin': 7.18.6_@babel+core@7.22.17
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/preset-env/7.20.2_@babel+core@7.20.5:
+  /@babel/preset-env/7.20.2_@babel+core@7.22.17:
     resolution: {integrity: sha512-1G0efQEWR1EHkKvKHqbG+IN/QdgwfByUpM5V5QroDzGV2t3S/WXNQd693cHiHTlCFMpr9B6FkPFXDA2lQcKoDg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.20.5
-      '@babel/core': 7.20.5
-      '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.20.5
+      '@babel/core': 7.22.17
+      '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.22.17
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-validator-option': 7.18.6
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.18.9_@babel+core@7.20.5
-      '@babel/plugin-proposal-async-generator-functions': 7.20.1_@babel+core@7.20.5
-      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-proposal-class-static-block': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-proposal-dynamic-import': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-proposal-export-namespace-from': 7.18.9_@babel+core@7.20.5
-      '@babel/plugin-proposal-json-strings': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-proposal-logical-assignment-operators': 7.18.9_@babel+core@7.20.5
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-proposal-numeric-separator': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-proposal-object-rest-spread': 7.20.2_@babel+core@7.20.5
-      '@babel/plugin-proposal-optional-catch-binding': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-proposal-optional-chaining': 7.18.9_@babel+core@7.20.5
-      '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-proposal-private-property-in-object': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.20.5
-      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.20.5
-      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.20.5
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.20.5
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.20.5
-      '@babel/plugin-syntax-import-assertions': 7.20.0_@babel+core@7.20.5
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.20.5
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.20.5
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.20.5
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.20.5
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.20.5
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.20.5
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.20.5
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.20.5
-      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.20.5
-      '@babel/plugin-transform-arrow-functions': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-transform-async-to-generator': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-transform-block-scoped-functions': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-transform-block-scoping': 7.20.5_@babel+core@7.20.5
-      '@babel/plugin-transform-classes': 7.20.2_@babel+core@7.20.5
-      '@babel/plugin-transform-computed-properties': 7.18.9_@babel+core@7.20.5
-      '@babel/plugin-transform-destructuring': 7.20.2_@babel+core@7.20.5
-      '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-transform-duplicate-keys': 7.18.9_@babel+core@7.20.5
-      '@babel/plugin-transform-exponentiation-operator': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-transform-for-of': 7.18.8_@babel+core@7.20.5
-      '@babel/plugin-transform-function-name': 7.18.9_@babel+core@7.20.5
-      '@babel/plugin-transform-literals': 7.18.9_@babel+core@7.20.5
-      '@babel/plugin-transform-member-expression-literals': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-transform-modules-amd': 7.19.6_@babel+core@7.20.5
-      '@babel/plugin-transform-modules-commonjs': 7.19.6_@babel+core@7.20.5
-      '@babel/plugin-transform-modules-systemjs': 7.19.6_@babel+core@7.20.5
-      '@babel/plugin-transform-modules-umd': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.20.5_@babel+core@7.20.5
-      '@babel/plugin-transform-new-target': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-transform-object-super': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-transform-parameters': 7.20.5_@babel+core@7.20.5
-      '@babel/plugin-transform-property-literals': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-transform-regenerator': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-transform-reserved-words': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-transform-shorthand-properties': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-transform-spread': 7.19.0_@babel+core@7.20.5
-      '@babel/plugin-transform-sticky-regex': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.20.5
-      '@babel/plugin-transform-typeof-symbol': 7.18.9_@babel+core@7.20.5
-      '@babel/plugin-transform-unicode-escapes': 7.18.10_@babel+core@7.20.5
-      '@babel/plugin-transform-unicode-regex': 7.18.6_@babel+core@7.20.5
-      '@babel/preset-modules': 0.1.5_@babel+core@7.20.5
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.18.9_@babel+core@7.22.17
+      '@babel/plugin-proposal-async-generator-functions': 7.20.1_@babel+core@7.22.17
+      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-proposal-class-static-block': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-proposal-dynamic-import': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-proposal-export-namespace-from': 7.18.9_@babel+core@7.22.17
+      '@babel/plugin-proposal-json-strings': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-proposal-logical-assignment-operators': 7.18.9_@babel+core@7.22.17
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-proposal-numeric-separator': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-proposal-object-rest-spread': 7.20.2_@babel+core@7.22.17
+      '@babel/plugin-proposal-optional-catch-binding': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-proposal-optional-chaining': 7.18.9_@babel+core@7.22.17
+      '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-proposal-private-property-in-object': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.22.17
+      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.22.17
+      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.22.17
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.22.17
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.22.17
+      '@babel/plugin-syntax-import-assertions': 7.20.0_@babel+core@7.22.17
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.22.17
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.22.17
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.22.17
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.22.17
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.22.17
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.22.17
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.22.17
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.22.17
+      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.22.17
+      '@babel/plugin-transform-arrow-functions': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-transform-async-to-generator': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-transform-block-scoped-functions': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-transform-block-scoping': 7.20.5_@babel+core@7.22.17
+      '@babel/plugin-transform-classes': 7.20.2_@babel+core@7.22.17
+      '@babel/plugin-transform-computed-properties': 7.18.9_@babel+core@7.22.17
+      '@babel/plugin-transform-destructuring': 7.20.2_@babel+core@7.22.17
+      '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-transform-duplicate-keys': 7.18.9_@babel+core@7.22.17
+      '@babel/plugin-transform-exponentiation-operator': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-transform-for-of': 7.18.8_@babel+core@7.22.17
+      '@babel/plugin-transform-function-name': 7.18.9_@babel+core@7.22.17
+      '@babel/plugin-transform-literals': 7.18.9_@babel+core@7.22.17
+      '@babel/plugin-transform-member-expression-literals': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-transform-modules-amd': 7.19.6_@babel+core@7.22.17
+      '@babel/plugin-transform-modules-commonjs': 7.19.6_@babel+core@7.22.17
+      '@babel/plugin-transform-modules-systemjs': 7.19.6_@babel+core@7.22.17
+      '@babel/plugin-transform-modules-umd': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.20.5_@babel+core@7.22.17
+      '@babel/plugin-transform-new-target': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-transform-object-super': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-transform-parameters': 7.20.5_@babel+core@7.22.17
+      '@babel/plugin-transform-property-literals': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-transform-regenerator': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-transform-reserved-words': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-transform-shorthand-properties': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-transform-spread': 7.19.0_@babel+core@7.22.17
+      '@babel/plugin-transform-sticky-regex': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.22.17
+      '@babel/plugin-transform-typeof-symbol': 7.18.9_@babel+core@7.22.17
+      '@babel/plugin-transform-unicode-escapes': 7.18.10_@babel+core@7.22.17
+      '@babel/plugin-transform-unicode-regex': 7.18.6_@babel+core@7.22.17
+      '@babel/preset-modules': 0.1.5_@babel+core@7.22.17
       '@babel/types': 7.20.5
-      babel-plugin-polyfill-corejs2: 0.3.3_@babel+core@7.20.5
-      babel-plugin-polyfill-corejs3: 0.6.0_@babel+core@7.20.5
-      babel-plugin-polyfill-regenerator: 0.4.1_@babel+core@7.20.5
+      babel-plugin-polyfill-corejs2: 0.3.3_@babel+core@7.22.17
+      babel-plugin-polyfill-corejs3: 0.6.0_@babel+core@7.22.17
+      babel-plugin-polyfill-regenerator: 0.4.1_@babel+core@7.22.17
       core-js-compat: 3.26.1
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/preset-modules/0.1.5_@babel+core@7.20.5:
+  /@babel/preset-modules/0.1.5_@babel+core@7.22.17:
     resolution: {integrity: sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.20.5
+      '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.22.17
+      '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.22.17
       '@babel/types': 7.20.7
       esutils: 2.0.3
     dev: true
 
-  /@babel/preset-typescript/7.18.6_@babel+core@7.20.5:
+  /@babel/preset-typescript/7.18.6_@babel+core@7.22.17:
     resolution: {integrity: sha512-s9ik86kXBAnD760aybBucdpnLsAt0jK1xqJn2juOn9lkOvSHV60os5hxoVJsPzMQxvnUJFAlkont2DvvaYEBtQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.18.6
       '@babel/helper-validator-option': 7.18.6
-      '@babel/plugin-transform-typescript': 7.20.2_@babel+core@7.20.5
+      '@babel/plugin-transform-typescript': 7.20.2_@babel+core@7.22.17
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@babel/runtime/7.18.6:
     resolution: {integrity: sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==}
@@ -1229,26 +1329,26 @@ packages:
       regenerator-runtime: 0.13.9
     dev: true
 
-  /@babel/template/7.18.10:
-    resolution: {integrity: sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==}
+  /@babel/template/7.22.15:
+    resolution: {integrity: sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/parser': 7.20.5
-      '@babel/types': 7.20.7
+      '@babel/code-frame': 7.22.13
+      '@babel/parser': 7.22.16
+      '@babel/types': 7.22.17
 
-  /@babel/traverse/7.20.5:
-    resolution: {integrity: sha512-WM5ZNN3JITQIq9tFZaw1ojLU3WgWdtkxnhM1AegMS+PvHjkM5IXjmYEGY7yukz5XS4sJyEf2VzWjI8uAavhxBQ==}
+  /@babel/traverse/7.22.17:
+    resolution: {integrity: sha512-xK4Uwm0JnAMvxYZxOVecss85WxTEIbTa7bnGyf/+EgCL5Zt3U7htUpEOWv9detPlamGKuRzCqw74xVglDWpPdg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.14
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.19.0
-      '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.20.5
-      '@babel/types': 7.20.7
+      '@babel/code-frame': 7.22.13
+      '@babel/generator': 7.22.15
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-hoist-variables': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/parser': 7.22.16
+      '@babel/types': 7.22.17
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
@@ -1268,6 +1368,14 @@ packages:
     dependencies:
       '@babel/helper-string-parser': 7.19.4
       '@babel/helper-validator-identifier': 7.19.1
+      to-fast-properties: 2.0.0
+
+  /@babel/types/7.22.17:
+    resolution: {integrity: sha512-YSQPHLFtQNE5xN9tHuZnzu8vPr61wVTBZdfv1meex1NBosa4iT05k/Jw06ddJugi4bk7The/oSwQGFcksmEJQg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.15
       to-fast-properties: 2.0.0
 
   /@esbuild/android-arm/0.16.3:
@@ -1459,7 +1567,7 @@ packages:
     dependencies:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.14
-      '@jridgewell/trace-mapping': 0.3.14
+      '@jridgewell/trace-mapping': 0.3.19
 
   /@jridgewell/resolve-uri/3.1.0:
     resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
@@ -1478,7 +1586,13 @@ packages:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
 
-  /@rollup/plugin-babel/6.0.3_4j2srlqc6eykr6xzbdvv3mhtsu:
+  /@jridgewell/trace-mapping/0.3.19:
+    resolution: {integrity: sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/sourcemap-codec': 1.4.14
+
+  /@rollup/plugin-babel/6.0.3_and2se5twrmmobjb5ricux3wau:
     resolution: {integrity: sha512-fKImZKppa1A/gX73eg4JGo+8kQr/q1HBQaCGKECZ0v4YBBv3lFqi14+7xyApECzvkLTHCifx+7ntcrvtBIRcpg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -1491,7 +1605,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-module-imports': 7.18.6
       '@rollup/pluginutils': 5.0.2_rollup@3.7.0
       '@types/babel__core': 7.1.20
@@ -1569,18 +1683,18 @@ packages:
   /@types/babel__generator/7.6.4:
     resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.22.17
 
   /@types/babel__template/7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
-      '@babel/parser': 7.20.5
-      '@babel/types': 7.20.7
+      '@babel/parser': 7.22.16
+      '@babel/types': 7.22.17
 
   /@types/babel__traverse/7.18.3:
     resolution: {integrity: sha512-1kbcJ40lLB7MHsj39U4Sh1uTd2E7rLEa79kmDpI6cy+XiXsteB3POdQomoq4FxszMrO3ZYchkhYJw7A2862b3w==}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.22.17
 
   /@types/estree/1.0.0:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
@@ -1599,62 +1713,62 @@ packages:
     dependencies:
       color-convert: 1.9.3
 
-  /babel-plugin-jsx-dom-expressions/0.36.0-beta.6_@babel+core@7.20.5:
-    resolution: {integrity: sha512-77V25mzfMTnV+eMqz12WPp38I20s1wxz++XV9CWe8HbLulWMIq+ws15Ol+Ehfb+SR8A38zMKL0HLAqfRVnVV1w==}
+  /babel-plugin-jsx-dom-expressions/0.36.10_@babel+core@7.22.17:
+    resolution: {integrity: sha512-QA2k/14WGw+RgcGGnEuLWwnu4em6CGhjeXtjvgOYyFHYS2a+CzPeaVQHDOlfuiBcjq/3hWMspHMIMnPEOIzdBg==}
     peerDependencies:
       '@babel/core': ^7.20.12
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.22.17
       '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.20.5
-      '@babel/types': 7.20.7
+      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.22.17
+      '@babel/types': 7.22.17
       html-entities: 2.3.3
       validate-html-nesting: 1.2.1
     dev: false
 
-  /babel-plugin-polyfill-corejs2/0.3.3_@babel+core@7.20.5:
+  /babel-plugin-polyfill-corejs2/0.3.3_@babel+core@7.22.17:
     resolution: {integrity: sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.20.5
-      '@babel/core': 7.20.5
-      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.20.5
+      '@babel/core': 7.22.17
+      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.22.17
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /babel-plugin-polyfill-corejs3/0.6.0_@babel+core@7.20.5:
+  /babel-plugin-polyfill-corejs3/0.6.0_@babel+core@7.22.17:
     resolution: {integrity: sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
-      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.20.5
+      '@babel/core': 7.22.17
+      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.22.17
       core-js-compat: 3.26.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /babel-plugin-polyfill-regenerator/0.4.1_@babel+core@7.20.5:
+  /babel-plugin-polyfill-regenerator/0.4.1_@babel+core@7.22.17:
     resolution: {integrity: sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.5
-      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.20.5
+      '@babel/core': 7.22.17
+      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.22.17
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /babel-preset-solid/1.7.0-beta.3_@babel+core@7.20.5:
-    resolution: {integrity: sha512-Rt26a3HKqrFkHCde8SNSjdlyB2r4AdK39lpbbxseDSIkfpZZjCO+SAiKixmWqZtIh6cOrrk0BhqZabAsuvq1zw==}
+  /babel-preset-solid/1.7.7_@babel+core@7.22.17:
+    resolution: {integrity: sha512-tdxVzx3kgcIjNXAOmGRbzIhFBPeJjSakiN9yM+IYdL/+LtXNnbGqb0Va5tJb8Sjbk+QVEriovCyuzB5T7jeTvg==}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.5
-      babel-plugin-jsx-dom-expressions: 0.36.0-beta.6_@babel+core@7.20.5
+      '@babel/core': 7.22.17
+      babel-plugin-jsx-dom-expressions: 0.36.10_@babel+core@7.22.17
     dev: false
 
   /balanced-match/1.0.2:
@@ -1674,6 +1788,16 @@ packages:
       balanced-match: 1.0.2
     dev: true
 
+  /browserslist/4.21.10:
+    resolution: {integrity: sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+    dependencies:
+      caniuse-lite: 1.0.30001534
+      electron-to-chromium: 1.4.519
+      node-releases: 2.0.13
+      update-browserslist-db: 1.0.11_browserslist@4.21.10
+
   /browserslist/4.21.4:
     resolution: {integrity: sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -1683,6 +1807,7 @@ packages:
       electron-to-chromium: 1.4.284
       node-releases: 2.0.6
       update-browserslist-db: 1.0.10_browserslist@4.21.4
+    dev: true
 
   /builtin-modules/3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
@@ -1691,6 +1816,10 @@ packages:
 
   /caniuse-lite/1.0.30001439:
     resolution: {integrity: sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==}
+    dev: true
+
+  /caniuse-lite/1.0.30001534:
+    resolution: {integrity: sha512-vlPVrhsCS7XaSh2VvWluIQEzVhefrUQcEsQWSS5A5V+dM07uv1qHeQzAOTGIMy9i3e9bH15+muvI/UHojVgS/Q==}
 
   /chalk/2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -1748,6 +1877,10 @@ packages:
 
   /electron-to-chromium/1.4.284:
     resolution: {integrity: sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==}
+    dev: true
+
+  /electron-to-chromium/1.4.519:
+    resolution: {integrity: sha512-kqs9oGYL4UFVkLKhqCTgBCYZv+wZ374yABDMqlDda9HvlkQxvSr7kgf4hfWVjMieDbX+1MwPHFBsOGCMIBaFKg==}
 
   /esbuild/0.16.3:
     resolution: {integrity: sha512-71f7EjPWTiSguen8X/kxEpkAS7BFHwtQKisCDDV3Y4GLGWBaoSCyD5uXkaUew6JDzA9FEN1W23mdnSwW9kqCeg==}
@@ -1799,8 +1932,8 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
 
-  /fsevents/2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents/2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -1904,8 +2037,8 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  /json5/2.2.1:
-    resolution: {integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==}
+  /json5/2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
 
@@ -1917,6 +2050,11 @@ packages:
   /lodash.debounce/4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
     dev: true
+
+  /lru-cache/5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+    dependencies:
+      yallist: 3.1.1
 
   /magic-string/0.26.7:
     resolution: {integrity: sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==}
@@ -1953,8 +2091,12 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  /node-releases/2.0.13:
+    resolution: {integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==}
+
   /node-releases/2.0.6:
     resolution: {integrity: sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==}
+    dev: true
 
   /once/1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -2096,7 +2238,7 @@ packages:
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
 
   /safe-buffer/5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -2104,18 +2246,23 @@ packages:
   /semver/6.3.0:
     resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
     hasBin: true
+    dev: true
+
+  /semver/6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   /seroval/0.5.0:
     resolution: {integrity: sha512-HhHyJhaNP78446cuyUEVVhrJMM9L/c1U83VxJofRiHvyBcqOwMBMlRNG+fTEx7k1BCjH81UoAFcbkzvgmRA6CQ==}
     engines: {node: '>=10'}
 
-  /solid-js/1.7.0-beta.3:
-    resolution: {integrity: sha512-g4oyZIkZ1eQLg0MCy3OYzFcGQK+dCeaOkUO9rf+90dDECFKRaogWo6n6Ov1CElaLE9ej//RhuaZrEs7bJpactw==}
+  /solid-js/1.7.11:
+    resolution: {integrity: sha512-JkuvsHt8jqy7USsy9xJtT18aF9r2pFO+GB8JQ2XGTvtF49rGTObB46iebD25sE3qVNvIbwglXOXdALnJq9IHtQ==}
     dependencies:
       csstype: 3.1.1
       seroval: 0.5.0
 
-  /solid-refresh/0.5.0_solid-js@1.7.0-beta.3:
+  /solid-refresh/0.5.0_solid-js@1.7.11:
     resolution: {integrity: sha512-kBsHSjqBUMXD2I7cU/batNE5WlXGiB5Otob9JDx4Zl5+Vt+a5naGxjPf81fg/c4lh++IdX2GF5CORxEcVzyTgg==}
     peerDependencies:
       solid-js: ^1.3
@@ -2123,7 +2270,7 @@ packages:
       '@babel/generator': 7.20.14
       '@babel/helper-module-imports': 7.18.6
       '@babel/types': 7.20.7
-      solid-js: 1.7.0-beta.3
+      solid-js: 1.7.11
     dev: false
 
   /source-map-js/1.0.2:
@@ -2192,6 +2339,17 @@ packages:
       browserslist: 4.21.4
       escalade: 3.1.1
       picocolors: 1.0.0
+    dev: true
+
+  /update-browserslist-db/1.0.11_browserslist@4.21.10:
+    resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+    dependencies:
+      browserslist: 4.21.10
+      escalade: 3.1.1
+      picocolors: 1.0.0
 
   /validate-html-nesting/1.2.1:
     resolution: {integrity: sha512-T1ab131NkP3BfXB7KUSgV7Rhu81R2id+L6NaJ7NypAAG5iV6gXnPpQE5RK1fvb+3JYsPTL+ihWna5sr5RN9gaQ==}
@@ -2228,7 +2386,7 @@ packages:
       resolve: 1.22.1
       rollup: 3.7.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
 
   /vitefu/0.2.3_vite@4.0.0:
     resolution: {integrity: sha512-75l7TTuU8isAhz1QFtNKjDkqjxvndfMC1AfIMjJ0ZQ59ZD0Ow9QOIsJJX16Wv9PS8f+zMzp6fHy5cCbKG/yVUQ==}
@@ -2244,6 +2402,9 @@ packages:
   /wrappy/1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
     dev: true
+
+  /yallist/3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
   /yargs-parser/20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import { transformAsync, TransformOptions } from '@babel/core';
-import ts from '@babel/preset-typescript';
 import solid from 'babel-preset-solid';
 import { readFileSync } from 'fs';
 import { mergeAndConcat } from 'merge-anything';
@@ -17,7 +16,6 @@ const runtimeCode = readFileSync(runtimeFilePath, 'utf-8');
 
 /** Possible options for the extensions property */
 export interface ExtensionOptions {
-  typescript?: boolean;
 }
 
 /** Configuration options for vite-plugin-solid. */
@@ -71,125 +69,7 @@ export interface Options {
     | TransformOptions
     | ((source: string, id: string, ssr: boolean) => TransformOptions)
     | ((source: string, id: string, ssr: boolean) => Promise<TransformOptions>);
-  typescript: {
-    /**
-     * Forcibly enables jsx parsing. Otherwise angle brackets will be treated as
-     * typescript's legacy type assertion var foo = <string>bar;. Also, isTSX:
-     * true requires allExtensions: true.
-     *
-     * @default false
-     */
-    isTSX?: boolean;
-
-    /**
-     * Replace the function used when compiling JSX expressions. This is so that
-     * we know that the import is not a type import, and should not be removed.
-     *
-     * @default React
-     */
-    jsxPragma?: string;
-
-    /**
-     * Replace the function used when compiling JSX fragment expressions. This
-     * is so that we know that the import is not a type import, and should not
-     * be removed.
-     *
-     * @default React.Fragment
-     */
-    jsxPragmaFrag?: string;
-
-    /**
-     * Indicates that every file should be parsed as TS or TSX (depending on the
-     * isTSX option).
-     *
-     * @default false
-     */
-    allExtensions?: boolean;
-
-    /**
-     * Enables compilation of TypeScript namespaces.
-     *
-     * @default uses the default set by @babel/plugin-transform-typescript.
-     */
-    allowNamespaces?: boolean;
-
-    /**
-     * When enabled, type-only class fields are only removed if they are
-     * prefixed with the declare modifier:
-     *
-     * > NOTE: This will be enabled by default in Babel 8
-     *
-     * @default false
-     *
-     * @example
-     * ```ts
-     * class A {
-     *   declare foo: string; // Removed
-     *   bar: string; // Initialized to undefined
-     *    prop?: string; // Initialized to undefined
-     *    prop1!: string // Initialized to undefined
-     * }
-     * ```
-     */
-    allowDeclareFields?: boolean;
-
-    /**
-     * When set to true, the transform will only remove type-only imports
-     * (introduced in TypeScript 3.8). This should only be used if you are using
-     * TypeScript >= 3.8.
-     *
-     * @default false
-     */
-    onlyRemoveTypeImports?: boolean;
-
-    /**
-     * When set to true, Babel will inline enum values rather than using the
-     * usual enum output:
-     *
-     * This option differs from TypeScript's --isolatedModules behavior, which
-     * ignores the const modifier and compiles them as normal enums, and aligns
-     * Babel's behavior with TypeScript's default behavior.
-     *
-     * ```ts
-     *  // Input
-     *  const enum Animals {
-     *    Fish
-     *  }
-     *  console.log(Animals.Fish);
-     *
-     *  // Default output
-     *  var Animals;
-     *
-     *  (function (Animals) {
-     *    Animals[Animals["Fish"] = 0] = "Fish";
-     *  })(Animals || (Animals = {}));
-     *
-     *  console.log(Animals.Fish);
-     *
-     *  // `optimizeConstEnums` output
-     *  console.log(0);
-     * ```
-     *
-     * However, when exporting a const enum Babel will compile it to a plain
-     * object literal so that it doesn't need to rely on cross-file analysis
-     * when compiling it:
-     *
-     * ```ts
-     * // Input
-     * export const enum Animals {
-     *   Fish,
-     * }
-     *
-     * // `optimizeConstEnums` output
-     * export var Animals = {
-     *     Fish: 0,
-     * };
-     * ```
-     *
-     * @default false
-     */
-    optimizeConstEnums?: boolean;
-  };
+  
   /**
    * Pass any additional [babel-plugin-jsx-dom-expressions](https://github.com/ryansolid/dom-expressions/tree/main/packages/babel-plugin-jsx-dom-expressions#plugin-options).
    * They will be merged with the defaults sets by [babel-preset-solid](https://github.com/solidjs/solid/blob/main/packages/babel-preset-solid/index.js#L8-L25).
@@ -288,7 +168,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
 
   return {
     name: 'solid',
-    enforce: 'pre',
+    enforce: 'post',
 
     async config(userConfig, { command }) {
       // We inject the dev mode only if the user explicitely wants it or if we are in dev (serve) mode
@@ -332,10 +212,9 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
 
       return {
         /**
-         * We only need esbuild on .ts or .js files.
-         * .tsx & .jsx files are handled by us
+         * Instruct esbuild to preserve JSX, since it will run before us.
          */
-        esbuild: { include: /\.ts$/ },
+        esbuild: { jsx: "preserve" },
         resolve: {
           conditions: [
             'solid',
@@ -408,22 +287,6 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
         // Vite handles sourcemap flattening
         inputSourceMap: false as any,
       };
-
-      // We need to know if the current file extension has a typescript options tied to it
-      const shouldBeProcessedWithTypescript = extensionsToWatch.some((extension) => {
-        if (typeof extension === 'string') {
-          return extension.includes('tsx');
-        }
-
-        const [extensionName, extensionOptions] = extension;
-        if (extensionName !== currentFileExtension) return false;
-
-        return extensionOptions.typescript;
-      });
-
-      if (shouldBeProcessedWithTypescript) {
-        opts.presets.push([ts, options.typescript || {}]);
-      }
 
       // Default value for babel user options
       let babelUserOptions: TransformOptions = {};


### PR DESCRIPTION
This PR fixes issue 95 by changing the plugin to run in the post-build phase (after esbuild transpiles TS), and instructing esbuild to preserve JSX.

Also updated the babel-preset-solid dependency
Moved @babel/preset-typescript to a devDependency