### PR TITLE
fix: regression from 2.8.1

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -328,6 +328,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
 
       const test = (userConfig as any).test || {};
 
+      // to simplify the processing of the config, we normalize the setupFiles to an array
       const userSetupFiles: string[] =
         typeof test.setupFiles === 'string' ? [test.setupFiles] : test.setupFiles || [];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -279,8 +279,8 @@ function containsSolidField(fields: Record<string, any>) {
   return false;
 }
 
-function getJestDomExport(test: { setupFiles: string[] }) {
-  return (test.setupFiles || []).some((path) => /jest-dom/.test(path))
+function getJestDomExport(setupFiles: string[]) {
+  return (setupFiles || []).some((path) => /jest-dom/.test(path))
     ? undefined
     : ['@testing-library/jest-dom/vitest', '@testing-library/jest-dom/extend-expect'].find(
         (path) => {
@@ -328,13 +328,18 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
 
       const test = (userConfig as any).test || {};
 
+      const userSetupFiles: string[] =
+        typeof test.setupFiles === 'string' ? [test.setupFiles] : test.setupFiles || [];
+
       if (userConfig.mode === 'test') {
         if (!test.environment && !options.ssr) {
           test.environment = 'jsdom';
         }
-        const jestDomImport = getJestDomExport(test);
+
+        const jestDomImport = getJestDomExport(userSetupFiles);
+
         if (jestDomImport) {
-          test.setupFiles = [...(test.setupFiles || []), require.resolve(jestDomImport)];
+          test.setupFiles = [...userSetupFiles, require.resolve(jestDomImport)];
         }
       }
 


### PR DESCRIPTION
The error is caused by using a config like below this:

```js
test: {
  setupFiles: 'src/setup-test.ts',
}
```

The current workaround is to use an array directly (but Vitest types tell everything is okay without string[])

```js
test: {
  setupFiles: ['src/setup-test.ts'],
}
```