### PR TITLE
Add new `refresh` config

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/babel__core": "^7.20.4",
     "babel-preset-solid": "^1.8.4",
     "merge-anything": "^5.1.7",
-    "solid-refresh": "^0.6.3",
+    "solid-refresh": "^0.7.0",
     "vitefu": "^0.2.5"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ dependencies:
     specifier: ^5.1.7
     version: 5.1.7
   solid-refresh:
-    specifier: ^0.6.3
-    version: 0.6.3(solid-js@1.8.5)
+    specifier: ^0.7.0
+    version: 0.7.0(solid-js@1.8.5)
   vitefu:
     specifier: ^0.2.5
     version: 0.2.5(vite@5.0.0)
@@ -2503,8 +2503,8 @@ packages:
       csstype: 3.1.3
       seroval: 0.12.4
 
-  /solid-refresh@0.6.3(solid-js@1.8.5):
-    resolution: {integrity: sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==}
+  /solid-refresh@0.7.0(solid-js@1.8.5):
+    resolution: {integrity: sha512-npG8PN2M4JBJoao6KCK0UisjDViClW7V/8GoezJyV3W12GXCMPy1okpLWBr9qvbsuwhCRL1s1rKFlPOaQw6XNg==}
     peerDependencies:
       solid-js: ^1.3
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import { readFileSync } from 'fs';
 import { mergeAndConcat } from 'merge-anything';
 import { createRequire } from 'module';
 import solidRefresh from 'solid-refresh/babel';
+// TODO use proper path
+import type { Options as RefreshOptions } from 'solid-refresh/dist/types/src/babel/core/types';
 import { createFilter } from 'vite';
 import type { Alias, AliasOptions, Plugin, FilterPattern } from 'vite';
 import { crawlFrameworkPkgs } from 'vitefu';
@@ -51,6 +53,7 @@ export interface Options {
    * This will inject HMR runtime in dev mode. Has no effect in prod. If
    * set to `false`, it won't inject the runtime in dev.
    *
+   * @deprecated use `refresh` instead
    * @default true
    */
   hot: boolean;
@@ -142,6 +145,8 @@ export interface Options {
      */
     builtIns?: string[];
   };
+
+  refresh: Omit<RefreshOptions & { disabled: boolean }, 'bundler' | 'fixRender'>;
 }
 
 function getExtension(filename: string): string {
@@ -255,7 +260,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
     },
 
     configResolved(config) {
-      needHmr = config.command === 'serve' && config.mode !== 'production' && options.hot !== false;
+      needHmr = config.command === 'serve' && config.mode !== 'production' && (options.hot !== false || !options.refresh.disabled);
     },
 
     resolveId(id) {
@@ -318,7 +323,12 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
         filename: id,
         sourceFileName: id,
         presets: [[solid, { ...solidOptions, ...(options.solid || {}) }]],
-        plugins: needHmr && !isSsr && !inNodeModules ? [[solidRefresh, { bundler: 'vite' }]] : [],
+        plugins: needHmr && !isSsr && !inNodeModules ? [[solidRefresh, {
+          bundler: 'vite',
+          fixRender: true,
+          imports: options.refresh.imports,
+          granular: options.refresh.granular,
+        }]] : [],
         ast: false,
         sourceMaps: true,
         configFile: false,


### PR DESCRIPTION
This PR adds the `refresh` option. Here are the following reasons:

- Aims to allow defining custom `render` and `createContext`. SolidStart would highly benefit on this given that it wraps it with `mount`.
- Aims to deprecate `hot` option.
- Since 0.7.0, `granular` mode is now enabled by default, but there's no configurable way to disable it in Vite plugin.