### PR TITLE
import solid as external to fix testing with npm

### DIFF
--- a/.changeset/fast-rocks-pump.md
+++ b/.changeset/fast-rocks-pump.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-solid": patch
+---
+
+import solid as external to fix testing with npm

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,8 +219,8 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
 
         test.server = test.server || {};
         test.server.deps = test.server.deps || {};
-        if (!test.server.deps.inline?.find((item: string | RegExp) => /solid-js/.test(item.toString()))) {
-          test.server.deps.inline = [...(test.server.deps.inline || []), /solid-js/];
+        if (!test.server.deps.external?.find((item: string | RegExp) => /solid-js/.test(item.toString()))) {
+          test.server.deps.external = [...(test.server.deps.external || []), /solid-js/];
         }
 
         const jestDomImport = getJestDomExport(userSetupFiles);


### PR DESCRIPTION
When installing the solid-start with-vitest template using npm, you get an error message on tests:

```
stderr | file://vitest-project/node_modules/solid-js/dist/dev.js:1932:13
You appear to have multiple instances of Solid. This can lead to unexpected behavior.

stderr | src/components/Counter.test.tsx > <Counter /> > increments value
computations created outside a `createRoot` or `render` will never be disposed
```

This is because npm imports work differently than pnpm imports and vitest does resolve the indirectly included modules using the package manager's resolver. Importing everything solid-js as external fixes this issue.