### PR TITLE
Fix Solid Start

### DIFF
--- a/.changeset/moody-pianos-wave.md
+++ b/.changeset/moody-pianos-wave.md
@@ -1,0 +1,4 @@
+'vite-plugin-solid': patch
+---
+
+Fix usage with Solid Start

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,6 +272,10 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
     },
 
     async transform(source, id, transformOptions) {
+      if (!filter(id)) {
+        return null;
+      }
+
       const isSsr = transformOptions && transformOptions.ssr;
       const currentFileExtension = getExtension(id);
 
@@ -281,14 +285,14 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
         typeof extension === 'string' ? extension : extension[0],
       );
 
-      if (!filter(id) || !(/\.[mc]?[tj]sx$/i.test(id) || allExtensions.includes(currentFileExtension))) {
+      id = id.replace(/\?.+$/, '');
+
+      if (!/\.[mc]?[tj]sx$/i.test(id) && !allExtensions.includes(currentFileExtension)) {
         return null;
       }
 
       const inNodeModules = /node_modules/.test(id);
-
       let solidOptions: { generate: 'ssr' | 'dom'; hydratable: boolean };
-
       if (options.ssr) {
         if (isSsr) {
           solidOptions = { generate: 'ssr', hydratable: true };
@@ -298,8 +302,6 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
       } else {
         solidOptions = { generate: 'dom', hydratable: false };
       }
-
-      id = id.replace(/\?.+$/, '');
 
       // We need to know if the current file extension has a typescript options tied to it
       const shouldBeProcessedWithTypescript = /\.[mc]?tsx$/i.test(id) || extensionsToWatch.some((extension) => {


### PR DESCRIPTION
Background: I accidently upgraded `vite-plugin-solid` to 2.10.2 in my Solid Start (`0.3.x`) project, and got that `React is not defined` error (https://github.com/solidjs/vite-plugin-solid/pull/103#issuecomment-1756117507)

I like the RegExp trick to test all 6 file extensions at once, but it didn't consider the query part in `id`, thus skipping transforming Solid Start files.

I guess Solid Start 0.7.x branch also needs this fix, because it still pins `vite-plugin-solid` at `~2.9.1`.