### PR TITLE
Support `?query` in ids

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -275,7 +275,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
         typeof extension === 'string' ? extension : extension[0],
       );
 
-      if (!filter(id) || !(/\.[mc]?[tj]sx(\?.*)?$/i.test(id) || allExtensions.includes(currentFileExtension))) {
+      if (!filter(id) || !(/^\.[mc]?[tj]sx$/i.test(currentFileExtension) || allExtensions.includes(currentFileExtension))) {
         return null;
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,7 @@ export interface Options {
 
 function getExtension(filename: string): string {
   const index = filename.lastIndexOf('.');
-  return index < 0 ? '' : filename.substring(index).replace(/\?.+$/, '');
+  return index < 0 ? '' : filename.substring(index).replace(/\?.*$/, '');
 }
 function containsSolidField(fields: Record<string, any>) {
   const keys = Object.keys(fields);
@@ -275,7 +275,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
         typeof extension === 'string' ? extension : extension[0],
       );
 
-      if (!filter(id) || !(/\.[mc]?[tj]sx$/i.test(id) || allExtensions.includes(currentFileExtension))) {
+      if (!filter(id) || !(/\.[mc]?[tj]sx(\?.*)?$/i.test(id) || allExtensions.includes(currentFileExtension))) {
         return null;
       }
 


### PR DESCRIPTION
Several Vite plugins, including [Civet's](https://github.com/DanielXMoore/Civet/tree/main/source/unplugin), generate artificial `id`s with a `?query` at the end. This should be ignored when detecting extensions, and indeed `getExtension` already did this. (I tweaked it slightly to also support `?` followed by no query, though that probably doesn't happen in practice.) But the `.[mc]?[tj]sx` extension detection failed to actually use this extension. Now it does.

As Ryan correctly guessed in Discord, this was first introduced in https://github.com/solidjs/vite-plugin-solid/commit/af0a43634389bdf10b898dfbcd5afdfe2a705cd7 — it affects every version after 2.8.3.