### PR TITLE
Support Vite 6 resolve conditions

### DIFF
--- a/.changeset/tame-comics-repair.md
+++ b/.changeset/tame-comics-repair.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-solid': patch
+---
+
+Support Vite 6's `resolve.conditions` breaking change

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'fs';
 import { mergeAndConcat } from 'merge-anything';
 import { createRequire } from 'module';
 import solidRefresh from 'solid-refresh/babel';
-import { createFilter } from 'vite';
+import { createFilter, version } from 'vite';
 import type { Alias, AliasOptions, Plugin, FilterPattern } from 'vite';
 import { crawlFrameworkPkgs } from 'vitefu';
 
@@ -13,6 +13,8 @@ const require = createRequire(import.meta.url);
 const runtimePublicPath = '/@solid-refresh';
 const runtimeFilePath = require.resolve('solid-refresh/dist/solid-refresh.mjs');
 const runtimeCode = readFileSync(runtimeFilePath, 'utf-8');
+
+const isVite6 = version.startsWith('6.');
 
 /** Possible options for the extensions property */
 export interface ExtensionOptions {
@@ -236,11 +238,13 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
          */
         // esbuild: { include: /\.ts$/ },
         resolve: {
-          conditions: [
-            'solid',
-            ...(replaceDev ? ['development'] : []),
-            ...(userConfig.mode === 'test' && !options.ssr ? ['browser'] : []),
-          ],
+          conditions: isVite6
+            ? undefined
+            : [
+                'solid',
+                ...(replaceDev ? ['development'] : []),
+                ...(userConfig.mode === 'test' && !options.ssr ? ['browser'] : []),
+              ],
           dedupe: nestedDeps,
           alias: [{ find: /^solid-refresh$/, replacement: runtimePublicPath }],
         },
@@ -251,6 +255,22 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
         ssr: solidPkgsConfig.ssr,
         ...(test.server ? { test } : {}),
       };
+    },
+
+    // @ts-ignore This hook only works in Vite 6
+    async configEnvironment(_, config, opts) {
+      config.resolve ??= {};
+      // Emulate Vite default fallback for `resolve.conditions` if not set
+      if (config.resolve.conditions == null) {
+        // @ts-ignore These exports only exist in Vite 6
+        const { defaultClientConditions, defaultServerConditions } = await import('vite');
+        if (config.consumer === 'client' || opts.isSsrTargetWebworker) {
+          config.resolve.conditions = [...defaultClientConditions];
+        } else {
+          config.resolve.conditions = [...defaultServerConditions];
+        }
+      }
+      config.resolve.conditions.push('solid');
     },
 
     configResolved(config) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -258,13 +258,13 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
     },
 
     // @ts-ignore This hook only works in Vite 6
-    async configEnvironment(_, config, opts) {
+    async configEnvironment(name, config, opts) {
       config.resolve ??= {};
       // Emulate Vite default fallback for `resolve.conditions` if not set
       if (config.resolve.conditions == null) {
         // @ts-ignore These exports only exist in Vite 6
         const { defaultClientConditions, defaultServerConditions } = await import('vite');
-        if (config.consumer === 'client' || opts.isSsrTargetWebworker) {
+        if (config.consumer === 'client' || name === 'client' || opts.isSsrTargetWebworker) {
           config.resolve.conditions = [...defaultClientConditions];
         } else {
           config.resolve.conditions = [...defaultServerConditions];


### PR DESCRIPTION
In Vite 6, the top-level `resolve.conditions` only apply to the client environment, so to apply in all environments generically, we need to use the new `configEnvironment` hook. https://main.vite.dev/guide/migration.html#default-value-for-resolve-conditions

I adapted this change from https://github.com/sveltejs/vite-plugin-svelte/pull/1020. I also remove the part where it updates the `development` and `browser` conditions for Vite 6. I've not tested them with Vite 6, but I feel like it could interfere with the default behaviour.

In practice I don't think a plugin should be modifying that. For `development`, Vite should decide by itself based on `NODE_ENV`. For `browser`, that seems Vitest specific and I'm not sure Vite plugins should be hardcoding Vitest specific logic.