### PR TITLE
Fix vite6 environment detection

### DIFF
--- a/.changeset/lucky-hats-arrive.md
+++ b/.changeset/lucky-hats-arrive.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-solid": patch
+---
+
+Fix vite6 environment detection

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,6 +181,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
   let needHmr = false;
   let replaceDev = false;
   let projectRoot = process.cwd();
+  let isTestMode = false;
 
   return {
     name: 'solid',
@@ -190,6 +191,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
       // We inject the dev mode only if the user explicitely wants it or if we are in dev (serve) mode
       replaceDev = options.dev === true || (options.dev !== false && command === 'serve');
       projectRoot = userConfig.root;
+      isTestMode = userConfig.mode === 'test';
 
       if (!userConfig.resolve) userConfig.resolve = {};
       userConfig.resolve.alias = normalizeAliases(userConfig.resolve && userConfig.resolve.alias);
@@ -270,7 +272,12 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
           config.resolve.conditions = [...defaultServerConditions];
         }
       }
-      config.resolve.conditions.push('solid');
+      config.resolve.conditions = [
+        'solid',
+        ...(replaceDev ? ['development'] : []),
+        ...(isTestMode && !opts.isSsrTargetWebworker ? ['browser'] : []),
+        ...config.resolve.conditions,
+      ];
     },
 
     configResolved(config) {


### PR DESCRIPTION
I believe this fixes the "Client-only API called on the server side. Run client-only code in onMount, or conditionally run" error when using vite6.

I'm not 100% on the implementation but tried to replicate the conditions that were removed in this pr. I am not sure if there is an order to where it picks up. I think `development` and `browser` weren't being added correctly and they were before.

https://github.com/solidjs/vite-plugin-solid/pull/163/files

Closes #171