### PR TITLE
Add continuous release (pkg.pr.new)

### DIFF
--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -1,0 +1,40 @@
+name: ⚡️ Continuous Releases
+
+on:
+  push:
+    branches:
+      - main
+  merge_group:
+  pull_request:
+
+jobs:
+  cr:
+    name: "⚡️ Continuous Releases"
+
+    strategy:
+      fail-fast: false
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v3
+        with:
+          # https://github.com/pnpm/pnpm/issues/8953
+          version: 9.15.3
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build start
+        run: pnpm run build
+
+      - name: Release
+        run: pnpm dlx pkg-pr-new@0.0 publish --compact


### PR DESCRIPTION
Let's add pkg.pr.new continuous release action, similar to solid-start

Locally it's easy enough to just with pnpm link, but i.e. in stackblitz repros ( like [here](https://github.com/solidjs/vite-plugin-solid/issues/171#issue-2797087166) ) it's a lot harder to test out PR versions, compared to simply adding this CR url to the package.json .