### PR TITLE
Revert "Fix duplicate vitest browser isntance"

### DIFF
--- a/.changeset/chilled-socks-invite.md
+++ b/.changeset/chilled-socks-invite.md
@@ -1,5 +1,0 @@
----
-'vite-plugin-solid': patch
----
-
-fix Vitest browser mode name collision issues

--- a/src/index.ts
+++ b/src/index.ts
@@ -254,7 +254,8 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
           include: [...nestedDeps, ...solidPkgsConfig.optimizeDeps.include],
           exclude: solidPkgsConfig.optimizeDeps.exclude,
         },
-        ssr: solidPkgsConfig.ssr
+        ssr: solidPkgsConfig.ssr,
+        ...(test.server ? { test } : {}),
       };
     },
 


### PR DESCRIPTION
Reverts solidjs/vite-plugin-solid#178

I'm not happy about this PR.

It was merged by mistake, before we added branch protection.

It does fix browser mode name collision of vitest, but it also break the `with-vitest` example of solid-start.