### PR TITLE
Fix duplicated test `setupFiles` in resolved vite config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -210,26 +210,29 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
         ? ['solid-js', 'solid-js/web', 'solid-js/store', 'solid-js/html', 'solid-js/h']
         : [];
 
-      const test = (userConfig as any).test || {};
-
+      const userTest = (userConfig as any) ?? {};
+      const test = {} as any;
       if (userConfig.mode === 'test') {
         // to simplify the processing of the config, we normalize the setupFiles to an array
         const userSetupFiles: string[] =
-          typeof test.setupFiles === 'string' ? [test.setupFiles] : test.setupFiles || [];
+          typeof userTest.setupFiles === 'string'
+            ? [userTest.setupFiles]
+            : userTest.setupFiles || [];
 
-        if (!test.environment && !options.ssr) {
+        if (!userTest.environment && !options.ssr) {
           test.environment = 'jsdom';
         }
 
-        test.server = test.server || {};
-        test.server.deps = test.server.deps || {};
-        if (!test.server.deps.external?.find((item: string | RegExp) => /solid-js/.test(item.toString()))) {
-          test.server.deps.external = [...(test.server.deps.external || []), /solid-js/];
+        if (
+          !userTest.server?.deps?.external?.find((item: string | RegExp) =>
+            /solid-js/.test(item.toString()),
+          )
+        ) {
+          test.server = { deps: { external: [/solid-js/] } };
         }
-
         const jestDomImport = getJestDomExport(userSetupFiles);
         if (jestDomImport) {
-          test.setupFiles = [...userSetupFiles, jestDomImport];
+          test.setupFiles = [jestDomImport];
         }
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -305,7 +305,10 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
         typeof extension === 'string' ? extension : extension[0],
       );
 
-      if (!filter(id) || !(/\.[mc]?[tj]sx$/i.test(id) || allExtensions.includes(currentFileExtension))) {
+      if (
+        !filter(id) ||
+        !(/\.[mc]?[tj]sx$/i.test(id) || allExtensions.includes(currentFileExtension))
+      ) {
         return null;
       }
 
@@ -326,17 +329,21 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
       id = id.replace(/\?.+$/, '');
 
       // We need to know if the current file extension has a typescript options tied to it
-      const shouldBeProcessedWithTypescript = /\.[mc]?tsx$/i.test(id) || extensionsToWatch.some((extension) => {
-        if (typeof extension === 'string') {
-          return extension.includes('tsx');
-        }
+      const shouldBeProcessedWithTypescript =
+        /\.[mc]?tsx$/i.test(id) ||
+        extensionsToWatch.some((extension) => {
+          if (typeof extension === 'string') {
+            return extension.includes('tsx');
+          }
 
-        const [extensionName, extensionOptions] = extension;
-        if (extensionName !== currentFileExtension) return false;
+          const [extensionName, extensionOptions] = extension;
+          if (extensionName !== currentFileExtension) return false;
 
-        return extensionOptions.typescript;
-      });
-      const plugins: NonNullable<NonNullable<babel.TransformOptions['parserOpts']>['plugins']> = ['jsx']
+          return extensionOptions.typescript;
+        });
+      const plugins: NonNullable<NonNullable<babel.TransformOptions['parserOpts']>['plugins']> = [
+        'jsx',
+      ];
 
       if (shouldBeProcessedWithTypescript) {
         plugins.push('typescript');


### PR DESCRIPTION
Previously, config was being "merged" when, in reality, vite expects just the overriden options and handles merging automatically under the hood.

This resulted in the `config.test.setupFiles` array being duplicated, which has the effect of making vitest run those twice.

If you had, for example,  a `beforeEach` hook there, it would be registered twice hence running twice before every test. And, if your code there has side effects (e.g. you're rendering to the DOM there like I am doing) they would get stacked, causing trouble.

The fix is to stop merging the config.

The file was also not formatted, so this PR also formats it. I separated it in two commits though, to reduce the noise.