### PR TITLE
update changeset access to public

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []


### PR DESCRIPTION
The NPM publishing breaks with:

`EUNSCOPED Can't restrict access to unscoped packages.`

Because the changeset is set to have restricted access. This PR set the access public, which was mentioned here:
- https://github.com/changesets/changesets/issues/503#issuecomment-1859307920