### PR TITLE
fix: tsr-split loading

### DIFF
--- a/.changeset/rare-owls-shop.md
+++ b/.changeset/rare-owls-shop.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-solid': patch
+---
+
+Support query string in tsx/jsx files

--- a/src/index.ts
+++ b/src/index.ts
@@ -302,6 +302,8 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
         typeof extension === 'string' ? extension : extension[0],
       );
 
+      id = id.replace(/\?.+$/, '');
+
       if (!filter(id) || !(/\.[mc]?[tj]sx$/i.test(id) || allExtensions.includes(currentFileExtension))) {
         return null;
       }
@@ -319,8 +321,6 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
       } else {
         solidOptions = { generate: 'dom', hydratable: false };
       }
-
-      id = id.replace(/\?.+$/, '');
 
       // We need to know if the current file extension has a typescript options tied to it
       const shouldBeProcessedWithTypescript = /\.[mc]?tsx$/i.test(id) || extensionsToWatch.some((extension) => {


### PR DESCRIPTION
When loading files in tanstack solid router it can add a ?tsr-split=component to the filename which our plugin skips because of the query string.

I moved up the replace of the query string up higher so that it doesn't filter it out a couple lines below.