### PR TITLE
Handle empty query string

### DIFF
--- a/.changeset/cold-fireants-fry.md
+++ b/.changeset/cold-fireants-fry.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-solid': patch
+---
+
+handle empty query string

--- a/src/index.ts
+++ b/src/index.ts
@@ -302,9 +302,13 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
         typeof extension === 'string' ? extension : extension[0],
       );
 
+      if (!filter(id)) {
+        return null
+      }
+
       id = id.replace(/\?.+$/, '');
 
-      if (!filter(id) || !(/\.[mc]?[tj]sx$/i.test(id) || allExtensions.includes(currentFileExtension))) {
+      if (!(/\.[mc]?[tj]sx$/i.test(id) || allExtensions.includes(currentFileExtension))) {
         return null;
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -306,7 +306,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
         return null
       }
 
-      id = id.replace(/\?.+$/, '');
+      id = id.replace(/\?.*$/, '');
 
       if (!(/\.[mc]?[tj]sx$/i.test(id) || allExtensions.includes(currentFileExtension))) {
         return null;


### PR DESCRIPTION
Follow up to
- #189 
- #161 

Tested to pass solid-start test suites, and the [tanstack router file-based code-splitting e2e tests](https://github.com/birkskyum/router/tree/solid-router-remake/e2e/solid-router/basic-file-based-code-splitting)