### PR TITLE
fix: adjust path to type declaration

### DIFF
--- a/.changeset/kind-items-listen.md
+++ b/.changeset/kind-items-listen.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-solid': patch
+---
+
+Adjust path to type declaration

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
-  "types": "dist/types/index.d.ts",
+  "types": "dist/types/src/index.d.ts",
   "exports": {
     "types": "./dist/types/index.d.ts",
     "import": "./dist/esm/index.mjs",


### PR DESCRIPTION
regression in 2.11.3 makes the types not found.

this makes sure the path to the type declaration is set correctly

