### PR TITLE
Fix server-side testing with vitest/ssr

### DIFF
--- a/.changeset/little-mice-mate.md
+++ b/.changeset/little-mice-mate.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-solid': patch
+---
+
+Fix server-side testing with vitest/ssr

--- a/src/index.ts
+++ b/src/index.ts
@@ -282,7 +282,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
       config.resolve.conditions = [
         'solid',
         ...(replaceDev ? ['development'] : []),
-        ...(isTestMode && !opts.isSsrTargetWebworker ? ['browser'] : []),
+        ...(isTestMode && !opts.isSsrTargetWebworker && !options.ssr ? ['browser'] : []),
         ...config.resolve.conditions,
       ];
     },


### PR DESCRIPTION
Fix server-side testing with vitest/ssr

# Initial error

Initial error when running vitest in ssr mode, since `vite-plugin-solid@2.11.1` (introduced by #173, reported by #211):

```
Error: renderToString is not supported in the browser, returning undefined
    at throwInBrowser (.../node_modules/solid-js/web/dist/dev.js:1089:15)
```

# Proposed fix

- This PR proposes to not add `'browser'` if `options.ssr`

I am not familiar with the code, and I am not sure if it could lead to issues for other setups.
An alternative could be to only add `'browser'` if the conditions don't already include `'node'`:
```javascript
-...(isTestMode && !opts.isSsrTargetWebworker ? ['browser'] : []),
+...(isTestMode && !opts.isSsrTargetWebworker && !config.resolve.conditions.includes('node') ? ['browser'] : []),
```

**Let me know which solution seems to be the best.**

# Additional note

The `opts.isSsrTargetWebworker` check seems to be inconsistant in the original code, I've left it untouched as I am not sure what is the intent there:

```javascript
// Original code: Uses `client` conditions if isSsrTargetWebworker is set
if (config.consumer === 'client' || name === 'client' || opts.isSsrTargetWebworker) {

// Original  code: Later, not using `browser` condition if isSsrTargetWebworker set
...(isTestMode && !opts.isSsrTargetWebworker ? ['browser'] : []),
```

Can original author comment on if the original logic seems consistent? (cc @bluwy @brenelz)

Thanks!

---

Fixes #211